### PR TITLE
fix: add prefix for internal or cluster APIs

### DIFF
--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/test/TestService.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/test/TestService.java
@@ -18,9 +18,9 @@ import retrofit2.http.Path;
 public interface TestService {
 
   // 定义一条接口请求
-  @POST("1.0.0/table")
+  @POST("/internal/api/meta/table")
   Call<JsonResult<TableInfo>> createTable(@Body TableInfo table);
 
-  @GET("/api/meta/tsd/query/{name}")
+  @GET("/internal/api/meta/tsd/query/{name}")
   Call<JsonResult<TableInfo>> queryTable(@Path("name") String name);
 }

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/web/controller/AdminController.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/web/controller/AdminController.java
@@ -19,7 +19,7 @@ import java.util.List;
  * @version : TestController.java, v 0.1 2022年03月03日 5:07 下午 jinsong.yjs Exp $
  */
 @RestController
-@RequestMapping("/webapi/admin")
+@RequestMapping("/internal/api/meta")
 public class AdminController {
 
   @Autowired

--- a/server/query/query-server/src/main/java/io/holoinsight/server/query/server/controllers/QueryController.java
+++ b/server/query/query-server/src/main/java/io/holoinsight/server/query/server/controllers/QueryController.java
@@ -22,7 +22,7 @@ import java.util.Collections;
  * @author xiangwanpeng
  */
 @RestController
-@RequestMapping("/api/v1/query")
+@RequestMapping("/cluster/api/v1/query")
 public class QueryController {
 
   @Autowired

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/EndpointApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/EndpointApi.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 @Api(value = "endpoint", description = "the endpoint API")
-@RequestMapping("/api/v1/endpoint")
+@RequestMapping("/cluster/api/v1/endpoint")
 public interface EndpointApi {
 
   @ApiOperation(value = "query endpoint list", nickname = "queryEndpointList", notes = "查询接口列表",

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/MetricApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/MetricApi.java
@@ -23,7 +23,7 @@ import java.util.List;
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen",
     date = "2020-01-21T07:37:08.930Z")
 @Api(value = "trace", description = "the trace API")
-@RequestMapping("/api/v1/metric")
+@RequestMapping("/cluster/api/v1/metric")
 public interface MetricApi {
 
   @ApiOperation(value = "list metrics", nickname = "listMetrics", notes = "列出所有指标名称。",

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/ServiceApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/ServiceApi.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 @Api(value = "service", description = "the service API")
-@RequestMapping("/api/v1/service")
+@RequestMapping("/cluster/api/v1/service")
 public interface ServiceApi {
 
   @ApiOperation(value = "query service list", nickname = "queryServiceList", notes = "查询服务列表",

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/ServiceInstanceApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/ServiceInstanceApi.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 @Api(value = "serviceInstance", description = "the serviceInstance API")
-@RequestMapping("/api/v1/serviceInstance")
+@RequestMapping("/cluster/api/v1/serviceInstance")
 public interface ServiceInstanceApi {
 
   @ApiOperation(value = "query serviceInstance list", nickname = "queryServiceInstanceList",

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/SlowSqlApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/SlowSqlApi.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 @Api(value = "slowSql", description = "the slowSql API")
-@RequestMapping("/api/v1/slowSql")
+@RequestMapping("/cluster/api/v1/slowSql")
 public interface SlowSqlApi {
 
   @ApiOperation(value = "query slow sql list", nickname = "querySlowSqlList", notes = "查询慢sql列表",

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/TopologyApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/TopologyApi.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 @Api(value = "topology", description = "the topology API")
-@RequestMapping("/api/v1/topology")
+@RequestMapping("/cluster/api/v1/topology")
 public interface TopologyApi {
 
   @ApiOperation(value = "query tenant topology", nickname = "queryTenantTopology",

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/TraceApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/TraceApi.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen",
     date = "2020-01-21T07:37:08.930Z")
 @Api(value = "trace", description = "the trace API")
-@RequestMapping("/api/v1/trace")
+@RequestMapping("/cluster/api/v1/trace")
 public interface TraceApi {
 
   @ApiOperation(value = "query basic traces", nickname = "queryTraces",

--- a/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/VirtualComponentApi.java
+++ b/server/storage/storage-server/storage-web/src/main/java/io/holoinsight/server/storage/web/VirtualComponentApi.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 @Api(value = "component", description = "the component API")
-@RequestMapping("/api/v1/component")
+@RequestMapping("/cluster/api/v1/component")
 public interface VirtualComponentApi {
 
   @ApiOperation(value = "query db list", nickname = "queryDbList", notes = "查询数据库列表",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Use prefixes to distinguish APIs that are only available on the local machine or within the cluster, so that they can be managed uniformly.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. The API for local debugging in the `meta` module is prefixed with `/internal`;
2. The APIs in the `query` and `storage` modules used to be called within the cluster are prefixed with `/cluster`.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Local `curl` command test passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
