### PR TITLE
feat(metrics): support CeresDB metrics storage

### DIFF
--- a/server/extension/extension-storage-ceresdbx/pom.xml
+++ b/server/extension/extension-storage-ceresdbx/pom.xml
@@ -13,6 +13,12 @@
 	<artifactId>extension-storage-ceresdbx</artifactId>
 	<description>holoinsight server side common module</description>
 	<dependencies>
+
+		<dependency>
+			<groupId>com.xzchaoo.commons</groupId>
+			<artifactId>commons-stat</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>io.holoinsight.server</groupId>
 			<artifactId>extension-storage</artifactId>
@@ -22,6 +28,22 @@
 			<groupId>io.ceresdb</groupId>
 			<artifactId>ceresdb-all</artifactId>
 			<version>0.1.0-RC</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>grpc-all</artifactId>
+					<groupId>io.grpc</groupId>
+				</exclusion>
+
+				<exclusion>
+					<artifactId>protobuf-java</artifactId>
+					<groupId>com.google.protobuf</groupId>
+				</exclusion>
+
+				<exclusion>
+					<artifactId>commons-compress</artifactId>
+					<groupId>org.apache.commons</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -68,5 +90,10 @@
 			<artifactId>protobuf-java-util</artifactId>
 			<scope>provided</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>io.holoinsight.server</groupId>
+            <artifactId>common-dao</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxClientManager.java
+++ b/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxClientManager.java
@@ -1,0 +1,119 @@
+package io.holoinsight.server.extension.ceresdbx;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.PostConstruct;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
+import io.ceresdb.CeresDBClient;
+import io.ceresdb.options.CeresDBOptions;
+import io.ceresdb.rpc.RpcOptions;
+import io.ceresdb.rpc.RpcOptions.LimitKind;
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.common.dao.entity.TenantOps;
+import io.holoinsight.server.common.dao.mapper.TenantOpsMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.util.Assert;
+
+/**
+ * <p>
+ * created at 2022/3/4
+ *
+ * @author xiangfeng.xzc
+ */
+class CeresdbxClientManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CeresdbxClientManager.class);
+  public static final int DEFAULT_MANAGEMENT_PORT = 5440;
+
+  private TenantOpsMapper tenantOpsMapper;
+
+  private Map<String, CeresDBxClientInstance> instances = new ConcurrentHashMap<>();
+
+  public CeresdbxClientManager(TenantOpsMapper tenantOpsMapper) {
+    this.tenantOpsMapper = tenantOpsMapper;
+  }
+
+  @PostConstruct
+  @Scheduled(fixedRate = 60000L)
+  public void refresh() {
+    QueryWrapper<TenantOps> wrapper = new QueryWrapper<>();
+    List<TenantOps> tenantOpsList = tenantOpsMapper.selectList(wrapper);
+    if (CollectionUtils.isNotEmpty(tenantOpsList)) {
+      for (TenantOps tenantOps : tenantOpsList) {
+        String tenant = tenantOps.getTenant();
+        Map<String, Object> json = J.toMap(tenantOps.getStorage());
+        Map<String, Object> metricConfig = (Map<String, Object>) json.get("metric");
+        Assert.notNull(metricConfig, String.format("metric conf not found: %s", tenantOps));
+        Map<String, Object> ceresdbConfig = (Map<String, Object>) metricConfig.get("ceresdbx");
+        if (Objects.isNull(ceresdbConfig) || ceresdbConfig.size() == 0) {
+          continue;
+        }
+        String accessUser = (String) ceresdbConfig.get("accessUser");
+        String accessKey = (String) ceresdbConfig.get("accessKey");
+        String address = (String) ceresdbConfig.get("address");
+        Object portObj = ceresdbConfig.get("port");
+        int port = Double.valueOf(String.valueOf(portObj)).intValue();
+        Object managePortObj = ceresdbConfig.get("managePort");
+        int managePort = 0;
+        if (Objects.nonNull(managePortObj)) {
+          managePort = Double.valueOf(String.valueOf(managePortObj)).intValue();
+        }
+        String newConfigKey = configKey(address, port, accessUser, accessKey);
+        CeresDBxClientInstance clientInstance = instances.get(tenant);
+        if (clientInstance == null
+            || !StringUtils.equals(clientInstance.getConfigKey(), newConfigKey)) {
+          RpcOptions rpcOptions = new RpcOptions();
+          rpcOptions.setLimitKind(LimitKind.None);
+          CeresDBOptions opts = CeresDBOptions.newBuilder(address, port)
+              .managementAddress(address, managePort != 0 ? managePort : DEFAULT_MANAGEMENT_PORT).tenant(accessUser, "", accessKey)
+              .maxInFlightWriteRows(10000).rpcOptions(rpcOptions).writeMaxRetries(2)
+              .readMaxRetries(2).maxWriteSize(512).build();
+          CeresDBClient client = new CeresDBClient();
+          try {
+            final boolean ret = client.init(opts);
+            LOGGER.info("Start CeresDBx client {}, with options: {}.", ret ? "success" : "failed",
+                opts);
+            CeresDBxClientInstance newInstance = new CeresDBxClientInstance(newConfigKey, client);
+            instances.put(tenant, newInstance);
+          } catch (Throwable e) {
+            LOGGER.error("create CeresDBx instance error", e);
+          }
+        }
+      }
+    }
+    if (instances.size() == 0) {
+      throw new RuntimeException("CeresDBx conf not found");
+    }
+  }
+
+  public CeresDBClient getClient(String tenant) {
+    if (StringUtils.isBlank(tenant)) {
+      tenant = "dev";
+    }
+    CeresDBxClientInstance ceresDBxClientInstance = instances.get(tenant);
+    Assert.notNull(ceresDBxClientInstance, "CeresDBx instance not found for tenant: " + tenant);
+    return ceresDBxClientInstance.getCeresDBClient();
+  }
+
+  private String configKey(String host, int port, String user, String accessKey) {
+    return host + port + user + accessKey;
+  }
+}
+
+
+@AllArgsConstructor
+@Data
+class CeresDBxClientInstance {
+  private final String configKey;
+  private final CeresDBClient ceresDBClient;
+}

--- a/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxMetricStorage.java
+++ b/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxMetricStorage.java
@@ -1,0 +1,450 @@
+package io.holoinsight.server.extension.ceresdbx;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.xzchaoo.commons.stat.StringsKey;
+import io.ceresdb.CeresDBClient;
+import io.ceresdb.models.Err;
+import io.ceresdb.models.FieldValue;
+import io.ceresdb.models.QueryOk;
+import io.ceresdb.models.QueryRequest;
+import io.ceresdb.models.Record;
+import io.ceresdb.models.Record.FieldDescriptor;
+import io.ceresdb.models.Rows;
+import io.ceresdb.models.Series;
+import io.ceresdb.models.Series.Builder;
+import io.ceresdb.models.SqlResult;
+import io.ceresdb.models.WriteOk;
+import io.grpc.Context;
+import io.holoinsight.server.extension.MetricStorage;
+import io.holoinsight.server.extension.ceresdbx.utils.StatUtils;
+import io.holoinsight.server.extension.ceresdbx.utils.StorageMonitor;
+import io.holoinsight.server.extension.model.QueryMetricsParam;
+import io.holoinsight.server.extension.model.QueryParam.SlidingWindow;
+import io.holoinsight.server.extension.model.QueryResult;
+import io.holoinsight.server.extension.model.QueryResult.Result;
+import io.holoinsight.server.extension.model.WriteMetricsParam;
+import io.holoinsight.server.extension.model.WriteMetricsParam.Point;
+import io.holoinsight.server.extension.model.PqlParam;
+import io.holoinsight.server.extension.model.QueryParam;
+import io.holoinsight.server.extension.model.QueryParam.QueryFilter;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author jinyan.ljw
+ * @date 2023/1/13
+ */
+public class CeresdbxMetricStorage implements MetricStorage {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CeresdbxMetricStorage.class);
+
+  CeresdbxClientManager ceresdbxClientManager;
+  private static final List<String> SUPPORT_SMH_UNIT = Lists.newArrayList("s", "m", "h");
+  private static final List<String> SUPPORT_DMY_UNIT = Lists.newArrayList("d", "M", "y");
+  public static final int DEFAULT_BATCH_RECORDS = 200;
+  public static final int DEFAULT_BATCH_POINTS = 512;
+  public static final int DEFAULT_METRIC_LIMIT = 100;
+
+  public CeresdbxMetricStorage(CeresdbxClientManager ceresdbxClientManager) {
+    this.ceresdbxClientManager = ceresdbxClientManager;
+  }
+
+  @Override
+  public Mono<Void> write(WriteMetricsParam writeMetricsParam) {
+    List<Point> points = writeMetricsParam.getPoints();
+    if (CollectionUtils.isEmpty(points)) {
+      return Mono.empty();
+    }
+    String tenant = writeMetricsParam.getTenant();
+    Iterator<Point> pointIter = points.iterator();
+    List<Rows> oneBatch = Lists.newLinkedList();
+    int dps = 0;
+    Set<String> metrics = Sets.newHashSet();
+    while (pointIter.hasNext()) {
+      Point point = pointIter.next();
+      dps += convertToRows(metrics, point, oneBatch);
+      if (!pointIter.hasNext() || oneBatch.size() >= DEFAULT_BATCH_RECORDS
+          || dps >= DEFAULT_BATCH_POINTS) {
+        List<Rows> oneBatch2 = oneBatch;
+        Context.ROOT.run(() -> doBatchInsert(metrics, tenant, oneBatch2));
+        oneBatch = Lists.newLinkedList();
+        dps = 0;
+      }
+    }
+    return Mono.empty();
+  }
+
+  private void doBatchInsert(Set<String> metrics, String tenant, List<Rows> oneBatch) {
+    long start = System.currentTimeMillis();
+    CeresDBClient client = ceresdbxClientManager.getClient(tenant);
+    CompletableFuture<io.ceresdb.models.Result<WriteOk, Err>> future = client.write(oneBatch);
+    future.whenComplete((result, throwable) -> {
+      if (result != null && result.isOk()) {
+        StatUtils.STORAGE_WRITE.add(StringsKey.of("CeresDBx", tenant, "Y"),
+            new long[] {1, oneBatch.size(), System.currentTimeMillis() - start});
+      } else {
+        StatUtils.STORAGE_WRITE.add(StringsKey.of("CeresDBx", tenant, "N"),
+            new long[] {1, oneBatch.size(), System.currentTimeMillis() - start});
+        if (result != null && null != result.getErr()) {
+          LOGGER.error("save metrics:{} to CeresDBx result:{}, error msg:{}", metrics, result,
+              result.getErr().getError());
+        } else if (null != throwable) {
+          LOGGER.error("save metrics:{} to CeresDBx result:{}, error msg:{}", metrics, result,
+              throwable);
+        } else {
+          LOGGER.error("save metrics:{} to CeresDBx error", metrics);
+        }
+      }
+    });
+  }
+
+  private int convertToRows(Set<String> metrics, Point point, List<Rows> oneBatch) {
+    Map<String, String> tags = point.getTags();
+    String metric = fixName(point.getMetricName());
+    metrics.add(metric);
+    Builder builder = Series.newBuilder(metric);
+    tags.forEach(builder::tag);
+    HashMap<String, FieldValue> fields = new HashMap<>();
+    fields.put("value", FieldValue.withDouble(point.getValue()));
+    oneBatch.add(builder.toRowsBuilder().fields(point.getTimeStamp(), fields).build());
+    return tags.size();
+  }
+
+  @Override
+  public List<Result> queryData(QueryParam queryParam) {
+    String whereStatement = parseWhere(queryParam);
+    String fromStatement = parseFrom(queryParam);
+    String sql = genSqlWithGroupBy(queryParam, fromStatement, whereStatement);
+    LOGGER.info("queryData queryparam:{}, sql:{}", queryParam, sql);
+    QueryRequest request =
+        QueryRequest.newBuilder().forMetrics(fixName(queryParam.getMetric())).ql(sql).build();
+    CompletableFuture<io.ceresdb.models.Result<QueryOk, Err>> qf =
+        ceresdbxClientManager.getClient(queryParam.getTenant()).query(request);
+    try {
+      final io.ceresdb.models.Result<QueryOk, Err> qr = qf.get();
+      if (!qr.isOk()) {
+        LOGGER.error("[CERESDBX_QUERY] failed to exec sql:{}, qr:{}, error:{}", sql, qr,
+            qr.getErr().getError());
+        throw new RuntimeException(qr.getErr().getError());
+      }
+      final List<Record> records = qr.getOk().mapToRecord().collect(Collectors.toList());
+      if (CollectionUtils.isEmpty(records)) {
+        return Lists.newArrayList();
+      }
+      String[] header = getHeader(records.get(0));
+      return transToResults(queryParam, header, records);
+    } catch (Exception e) {
+      LOGGER.error("[CERESDBX_QUERY] failed to exec sql:{}, error:{}", sql, e.getMessage());
+      return Lists.newArrayList();
+    }
+  }
+
+  private List<Result> transToResults(QueryParam queryParam, String[] header,
+      List<Record> records) {
+    Map<Map<String, String>, Result> tagsWithResults =
+        getTagsWithResults(queryParam, header, records);
+    SlidingWindow slidingWindow = queryParam.getSlidingWindow();
+    if (Objects.nonNull(slidingWindow) && slidingWindow.getWindowMs() > 0
+        && !StringUtils.equalsIgnoreCase("none", slidingWindow.getAggregator())) {
+      return SlidingWindowResult(queryParam.getStart(), queryParam.getEnd(), slidingWindow,
+          tagsWithResults);
+    }
+    return Lists.newArrayList(tagsWithResults.values());
+  }
+
+  private Map<Map<String, String>, Result> getTagsWithResults(QueryParam queryParam,
+      String[] header, List<Record> records) {
+    Map<Map<String, String>, Result> tagsToResult = Maps.newHashMap();
+    for (Record record : records) {
+      Result result = new Result();
+      QueryResult.Point point = new QueryResult.Point();
+      Map<String, String> tags = Maps.newHashMap();
+      for (String name : header) {
+        if ("value".equals(name)) {
+          Object value = record.get(name);
+          if (Objects.nonNull(value)) {
+            point.setValue((((Number) value).doubleValue()));
+          } else {
+            point.setValue(0D);
+          }
+          continue;
+        }
+        if ("timestamp".equals(name)) {
+          point.setTimestamp(record.getTimestamp(name));
+          continue;
+        }
+        if ("tsid".equals(name)) {
+          continue;
+        }
+        tags.put(name, record.get(name).toString());
+      }
+      Result existResult = tagsToResult.get(tags);
+      if (existResult != null) {
+        existResult.getPoints().add(point);
+      } else {
+        result.setMetric(fixName(queryParam.getMetric()));
+        result.setTags(tags);
+        result.setPoints(Lists.newArrayList(point));
+        tagsToResult.put(tags, result);
+      }
+    }
+    return tagsToResult;
+  }
+
+  private String[] getHeader(Record record) {
+    List<FieldDescriptor> fieldDescriptors = record.getFieldDescriptors();
+    String[] headers = new String[fieldDescriptors.size()];
+    for (int i = 0; i < fieldDescriptors.size(); i++) {
+      headers[i] = fieldDescriptors.get(i).getName();
+    }
+    return headers;
+  }
+
+  private List<Result> SlidingWindowResult(long start, long end, SlidingWindow slidingWindow,
+      Map<Map<String, String>, Result> tagsWithResults) {
+    String aggregator = slidingWindow.getAggregator();
+    long windowMs = slidingWindow.getWindowMs();
+    long window = windowMs / 1000 / 60;
+    long windowStart = start / 1000 * 1000;
+    long windowStartEnd = end / 1000 * 1000;
+    tagsWithResults.forEach((tags, data) -> {
+      long now = windowStart;
+      LinkedList<Double> windows = Lists.newLinkedList();
+      ArrayList<QueryResult.Point> windowPoints = Lists.newArrayList();
+      while (now <= windowStartEnd) {
+        Map<Long, QueryResult.Point> timePointMap = data.getPoints().stream()
+            .collect(Collectors.toMap(QueryResult.Point::getTimestamp, Function.identity()));
+        QueryResult.Point point = timePointMap.get(now);
+        if (Objects.nonNull(point)) {
+          windows.add(point.getValue());
+        } else {
+          windows.add(-1D);
+        }
+        // 满足一个窗口，才开始做计算；
+        if (windows.size() == window) {
+          Double aggregatorValue = getAggregatorValue(windows, aggregator);
+          QueryResult.Point windowPoint = new QueryResult.Point();
+          windowPoint.setTimestamp(now);
+          windowPoint.setValue(aggregatorValue);
+          windowPoints.add(windowPoint);
+          windows.removeFirst();
+        }
+        now += 60 * 1000;
+      }
+      data.setPoints(windowPoints);
+    });
+    return Lists.newArrayList(tagsWithResults.values());
+  }
+
+  private Double getAggregatorValue(LinkedList<Double> windows, String aggregator) {
+    Stream<Double> doubleStream = windows.stream().filter(value -> value != -1D);
+    if (StringUtils.equalsIgnoreCase("avg", aggregator)) {
+      return doubleStream.collect(Collectors.averagingDouble(Double::doubleValue));
+    } else if (StringUtils.equalsIgnoreCase("max", aggregator)) {
+      return doubleStream.max(Double::compareTo).orElse(0D);
+    } else if (StringUtils.equalsIgnoreCase("min", aggregator)) {
+      return doubleStream.min(Double::compareTo).orElse(0D);
+    } else if (StringUtils.equalsIgnoreCase("sum", aggregator)) {
+      return doubleStream.mapToDouble(Double::doubleValue).sum();
+    } else if (StringUtils.equalsIgnoreCase("count", aggregator)) {
+      return ((Long) doubleStream.count()).doubleValue();
+    }
+    return 0D;
+  }
+
+  private String genSqlWithGroupBy(QueryParam queryParam, String fromSql, String whereSql) {
+    List<String> groupBy = queryParam.getGroupBy();
+    String aggregator = queryParam.getAggregator();
+    String sql;
+    if (!CollectionUtils.isEmpty(groupBy)) {
+      String groupByStr = StringUtils.join(groupBy, ",");
+      if (StringUtils.isNotBlank(aggregator) && !StringUtils.equalsIgnoreCase("none", aggregator)) {
+        if (StringUtils.isNotBlank(whereSql)) {
+          sql =
+              "SELECT timestamp, %s, %s(value) as value FROM %s WHERE %s group by timestamp, %s ORDER BY timestamp";
+          return String.format(sql, groupByStr, aggregator, fromSql, whereSql, groupByStr);
+        } else {
+          sql =
+              "SELECT timestamp, %s, %s(value) as value FROM %s group by timestamp, %s ORDER BY timestamp";
+          return String.format(sql, groupByStr, aggregator, fromSql, groupByStr);
+        }
+      } else {
+        if (StringUtils.isNotBlank(whereSql)) {
+          sql = "SELECT timestamp, %s, value FROM %s WHERE %s ORDER BY timestamp";
+          return String.format(sql, groupByStr, fromSql, whereSql);
+        } else {
+          sql = "SELECT timestamp, %s, value FROM %s ORDER BY timestamp";
+          return String.format(sql, groupByStr, fromSql);
+        }
+      }
+    } else if (StringUtils.isNotBlank(whereSql)) {
+      sql = "SELECT * FROM %s WHERE %s ORDER BY timestamp";
+      return String.format(sql, fromSql, whereSql);
+    } else {
+      sql = "SELECT * FROM %s ORDER BY timestamp";
+      return String.format(sql, fromSql);
+    }
+  }
+
+  private String parseWhere(QueryParam queryParam) {
+    StringBuilder whereSqlBuilder = new StringBuilder();
+    boolean isNestedQuery = StringUtils.isNotBlank(queryParam.getDownsample())
+        && StringUtils.isNotBlank(queryParam.getAggregator())
+        && !StringUtils.equalsIgnoreCase(queryParam.getAggregator(), "none");
+    if (!isNestedQuery) {
+      long start = queryParam.getStart();
+      long end = queryParam.getEnd();
+      whereSqlBuilder.append("timestamp >= ").append(start).append(" AND ").append(" timestamp < ")
+          .append(end);
+    }
+    List<QueryFilter> filters = queryParam.getFilters();
+    if (!CollectionUtils.isEmpty(filters)) {
+      if (!isNestedQuery) {
+        whereSqlBuilder.append(" AND ");
+      }
+      for (int i = 0; i < filters.size(); i++) {
+        QueryFilter queryFilter = filters.get(i);
+        String type = queryFilter.getType();
+        if (StringUtils.equalsIgnoreCase(type, "literal_or")) {
+          whereSqlBuilder.append(queryFilter.getName()).append(" IN ('")
+              .append(queryFilter.getValue().replace("|", "','")).append("')");
+        } else if (StringUtils.equalsIgnoreCase(type, "not_literal_or")) {
+          whereSqlBuilder.append(queryFilter.getName()).append(" NOT IN ('")
+              .append(queryFilter.getValue().replace("|", "','")).append("')");
+        } else if (StringUtils.equalsIgnoreCase(type, "literal")) {
+          whereSqlBuilder.append(queryFilter.getName()).append(" = '")
+              .append(queryFilter.getValue()).append("'");
+        } else if (StringUtils.equalsIgnoreCase(type, "not_literal")) {
+          whereSqlBuilder.append(queryFilter.getName()).append(" != '")
+              .append(queryFilter.getValue()).append("'");
+        } else {
+          // todo wildcard, regexp, not_regexp_match
+          throw new IllegalArgumentException(String.format("not support %s filter", type));
+        }
+        if (i != filters.size() - 1) {
+          whereSqlBuilder.append(" AND ");
+        }
+      }
+    }
+    return whereSqlBuilder.toString();
+  }
+
+  private String parseFrom(QueryParam queryParam) {
+    String downsample = queryParam.getDownsample();
+    String fromMetrics = fixName(queryParam.getMetric());
+    String aggregator = queryParam.getAggregator();
+    if (StringUtils.isNotBlank(downsample) && StringUtils.isNotBlank(aggregator)
+        && !StringUtils.equalsIgnoreCase(aggregator, "none")) {
+      String downsampleSql = "(SELECT time_bucket(`%s`, '%s') as timestamp, %s,"
+          + " %s(value) as value FROM %s WHERE timestamp >= %s AND timestamp < %s group by time_bucket(`%s`, '%s'),%s)";
+      String interval = getInterval(downsample);
+      if (StringUtils.isNotBlank(interval)) {
+        String tagNames = getTagNames(queryParam);
+        fromMetrics = String.format(downsampleSql, "timestamp", interval, tagNames, aggregator,
+            queryParam.getMetric(), queryParam.getStart(), queryParam.getEnd(), "timestamp",
+            interval, tagNames);
+      }
+    }
+    return fromMetrics;
+  }
+
+  private String getTagNames(QueryParam queryParam) {
+    Set<String> fields = querySchema(queryParam).getTags().keySet();
+    return StringUtils.join(fields, ",");
+  }
+
+  private String getInterval(String str) {
+    String lastChar = StringUtils.substring(str, str.length() - 1, str.length());
+    if (SUPPORT_SMH_UNIT.contains(lastChar)) {
+      return "PT" + str.toUpperCase();
+    } else if (SUPPORT_DMY_UNIT.contains(lastChar)) {
+      return "P" + str.toUpperCase();
+    }
+    return null;
+  }
+
+  @Override
+  public List<Result> queryTags(QueryParam queryParam) {
+    List<Result> results = queryData(queryParam);
+    return results;
+  }
+
+  @Override
+  public void deleteKeys(QueryParam queryParam) {}
+
+  @Override
+  public Result querySchema(QueryParam queryParam) {
+    String metric = fixName(queryParam.getMetric());
+    SqlResult sqlResult = execSQL(queryParam.getTenant(), "DESCRIBE " + metric);
+    Result result = new Result();
+    result.setMetric(metric);
+    Map<String, String> tags = Maps.newHashMap();
+    List<Map<String, Object>> rows = sqlResult.getRows();
+    if (CollectionUtils.isEmpty(rows)) {
+      result.setTags(Maps.newHashMap());
+      return result;
+    }
+    rows.stream().filter(row -> (boolean) row.get("is_tag"))
+        .forEach(map -> tags.put(map.get("name").toString(), "-"));
+    result.setTags(tags);
+    return result;
+  }
+
+  @Override
+  public List<String> queryMetrics(QueryMetricsParam queryParam) {
+    SqlResult sqlResult =
+        execSQL(queryParam.getTenant(), "show tables like '" + queryParam.getName() + "%%'");
+    List<Map<String, Object>> rows = sqlResult.getRows();
+    List<String> result = Lists.newArrayList();
+    if (CollectionUtils.isEmpty(rows)) {
+      return result;
+    }
+    int limit = queryParam.getLimit() > 0 ? queryParam.getLimit() : DEFAULT_METRIC_LIMIT;
+    rows.stream().limit(limit).forEach(map -> result.add(map.get("Tables").toString()));
+    return result;
+  }
+
+  @Override
+  public List<Result> pqlInstantQuery(PqlParam pqlParam) {
+    return null;
+  }
+
+  @Override
+  public List<Result> pqlRangeQuery(PqlParam pqlParam) {
+    return null;
+  }
+
+  public SqlResult execSQL(String tenant, String sql) {
+    try {
+      LOGGER.info("[ceresdbx_exec] {}, exec sql:{} ", tenant, sql);
+      return ceresdbxClientManager.getClient(tenant).management().executeSql(sql);
+    } catch (Exception e) {
+      LOGGER.error("[ceresdbx_exec] {} failed to exec sql:{}, error:{}", tenant, sql,
+          e.getMessage(), e);
+    }
+    return SqlResult.EMPTY_RESULT;
+  }
+
+  private String fixName(String name) {
+    return name.replace('.', '_');
+  }
+
+}

--- a/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/HoloinsightCeresdbxConfiguration.java
+++ b/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/HoloinsightCeresdbxConfiguration.java
@@ -3,7 +3,10 @@
  */
 package io.holoinsight.server.extension.ceresdbx;
 
+import io.holoinsight.server.common.dao.mapper.TenantOpsMapper;
+import io.holoinsight.server.extension.MetricStorage;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -13,5 +16,15 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(value = "holoinsight.metric.storage.type", havingValue = "ceresdbx")
 public class HoloinsightCeresdbxConfiguration {
+
+  @Bean
+  public CeresdbxClientManager ceresdbxClientManager(TenantOpsMapper tenantOpsMapper) {
+    return new CeresdbxClientManager(tenantOpsMapper);
+  }
+
+  @Bean
+  public MetricStorage ceresdbxMetricStorage(CeresdbxClientManager ceresdbxClientManager) {
+    return new CeresdbxMetricStorage(ceresdbxClientManager);
+  }
 
 }

--- a/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/utils/StatUtils.java
+++ b/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/utils/StatUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.extension.ceresdbx.utils;
+
+import com.xzchaoo.commons.stat.StatAccumulator;
+import com.xzchaoo.commons.stat.StatManager;
+import com.xzchaoo.commons.stat.StringsKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>
+ * created at 2022/3/17
+ *
+ * @author sw1136562366
+ */
+public final class StatUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger("STAT");
+
+  private static final StatManager SM = new StatManager(60000, LOGGER::info, false);
+  public static final StatAccumulator<StringsKey> STORAGE_WRITE = SM.create("STORAGE_WRITE");
+  private static final StatManager SM1S = new StatManager(1000, LOGGER::info, false);
+
+  static {
+    SM.start();
+    SM1S.start();
+  }
+
+  private StatUtils() {}
+}

--- a/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/utils/StorageMonitor.java
+++ b/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/utils/StorageMonitor.java
@@ -1,0 +1,107 @@
+package io.holoinsight.server.extension.ceresdbx.utils;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import lombok.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author jinyan.ljw
+ * @Description Storage Monitor
+ * @date 2023/1/16
+ */
+public class StorageMonitor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StorageMonitor.class);
+  private static Map<String, Body[]> map = new ConcurrentHashMap<>();
+
+  // 监控调度线程
+  private static final ScheduledThreadPoolExecutor monitorScheduler =
+      new ScheduledThreadPoolExecutor(2, (r) -> new Thread(r, "storage-monitor"));
+
+  private static final int REFRESH_PERIOD = 5;
+
+  static {
+    monitorScheduler.scheduleAtFixedRate(() -> {
+      try {
+        map.forEach((key, bodies) -> {
+          if (bodies == null || bodies.length == 0) {
+            return;
+          }
+          for (Body body : bodies) {
+            if (body == null || body.getSize().get() == 0.0) {
+              continue;
+            }
+            int reqs = body.getReqs().getAndSet(0);
+            String resultStr = body.isResult() ? "success" : "fail";
+            String metricName = body.table;
+            String storageType = body.storageType;
+            LOGGER.info(
+                "[STORAGE-MONITOR][{}]save data for table:[{}] to [{}], period:[{}], size:[{}], dps:[{}], "
+                    + "avg-rpcTime:[{}],avg-delay:[{}], tenant:[{}], reqs:[{}].",
+                resultStr, metricName, storageType, body.getPeriod(), body.getSize().getAndSet(0),
+                body.getDps().getAndSet(0), body.getRpcTime().getAndSet(0) / reqs,
+                body.getDelay().getAndSet(0) / reqs, body.getTenant(), reqs);
+          }
+        });
+      } catch (Exception e) {
+        LOGGER.error("[STORAGE-MONITOR] error", e);
+      }
+    }, REFRESH_PERIOD, REFRESH_PERIOD, TimeUnit.SECONDS);
+  }
+
+  @Data
+  static class Body {
+    String table;
+    String storageType;
+    AtomicInteger size;
+    AtomicInteger dps;
+    AtomicInteger reqs;
+    AtomicDouble rpcTime;
+    AtomicDouble delay;
+    String tenant;
+    long period;
+    boolean result;
+
+    public Body(String table, String storageType, int size, int dps, double rpcTime, double delay,
+        String tenant, long period, boolean result) {
+      this.table = table;
+      this.storageType = storageType;
+      this.size = new AtomicInteger(size);
+      this.dps = new AtomicInteger(dps);
+      this.rpcTime = new AtomicDouble(rpcTime);
+      this.delay = new AtomicDouble(delay);
+      this.tenant = tenant;
+      this.reqs = new AtomicInteger(1);
+      this.period = period;
+      this.result = result;
+    }
+  }
+
+  public static void monitor(String storageType, String table, int size, int dps, double rpcTime,
+      double delay, String tenant, boolean result, long period) {
+    String key = table + tenant + storageType;
+    if (!map.containsKey(key)) {
+      map.put(key, new Body[2]);
+    }
+    Body[] bodies = map.get(key);
+    int idx = result ? 1 : 0;
+    Body body = bodies[idx];
+    if (body == null) {
+      body = new Body(storageType, table, size, dps, rpcTime, delay, tenant, period, result);
+      bodies[idx] = body;
+    } else {
+      body.getSize().addAndGet(size);
+      body.getDps().addAndGet(dps);
+      body.getRpcTime().addAndGet(rpcTime);
+      body.getDelay().addAndGet(delay);
+      body.getReqs().addAndGet(1);
+      body.setPeriod(period);
+    }
+  }
+}

--- a/server/gateway/gateway-boot/src/main/java/io/holoinsight/server/gateway/bootstrap/HoloinsightGatewayConfiguration.java
+++ b/server/gateway/gateway-boot/src/main/java/io/holoinsight/server/gateway/bootstrap/HoloinsightGatewayConfiguration.java
@@ -14,9 +14,11 @@ import io.holoinsight.server.common.springboot.HoloinsightProperties;
 import io.holoinsight.server.common.threadpool.ThreadPoolConfiguration;
 import io.holoinsight.server.extension.MetricStorage;
 import io.holoinsight.server.extension.NoopMetricStorage;
+import io.holoinsight.server.extension.ceresdbx.HoloinsightCeresdbxConfiguration;
 import io.holoinsight.server.gateway.core.grpc.GatewayProperties;
 
 import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -35,9 +37,10 @@ import org.springframework.context.annotation.Import;
 @EnableConfigurationProperties({HoloinsightProperties.class, GatewayProperties.class})
 @Import({ConfigConfiguration.class, GroovyConfiguration.class, ThreadPoolConfiguration.class,
     InternalWebApiSecurityConfiguration.class, ApiKeyAutoConfiguration.class,
-    CommonDaoConfiguration.class})
+    CommonDaoConfiguration.class, HoloinsightCeresdbxConfiguration.class})
 public class HoloinsightGatewayConfiguration {
   @Bean
+  @ConditionalOnMissingBean
   public MetricStorage metricStorage() {
     return new NoopMetricStorage();
   }

--- a/server/gateway/gateway-core/pom.xml
+++ b/server/gateway/gateway-core/pom.xml
@@ -20,6 +20,11 @@
 		</dependency>
 		<dependency>
 			<groupId>io.holoinsight.server</groupId>
+			<artifactId>extension-storage-ceresdbx</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.holoinsight.server</groupId>
 			<artifactId>gateway-dao-gen</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/server/query/query-boot/src/main/java/io/holoinsight/server/query/bootstrap/HoloinsightQueryConfiguration.java
+++ b/server/query/query-boot/src/main/java/io/holoinsight/server/query/bootstrap/HoloinsightQueryConfiguration.java
@@ -5,7 +5,7 @@ package io.holoinsight.server.query.bootstrap;
 
 import io.holoinsight.server.common.springboot.ConditionalOnRole;
 import io.holoinsight.server.common.threadpool.ThreadPoolConfiguration;
-
+import io.holoinsight.server.extension.ceresdbx.HoloinsightCeresdbxConfiguration;
 import io.holoinsight.server.query.service.QueryService;
 import io.holoinsight.server.query.service.impl.DefaultQueryServiceImpl;
 import org.mybatis.spring.annotation.MapperScan;
@@ -25,7 +25,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @MapperScan(basePackages = {"io.holoinsight.server.query.dal.mapper",
     "io.holoinsight.server.common.dao.mapper"})
 @ConditionalOnRole("query")
-@Import({ThreadPoolConfiguration.class})
+@Import({ThreadPoolConfiguration.class, HoloinsightCeresdbxConfiguration.class})
 public class HoloinsightQueryConfiguration {
   @Bean
   public QueryService queryService() {

--- a/server/query/query-service/pom.xml
+++ b/server/query/query-service/pom.xml
@@ -20,6 +20,12 @@
 		</dependency>
 		<dependency>
 			<groupId>io.holoinsight.server</groupId>
+			<artifactId>extension-storage-ceresdbx</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.holoinsight.server</groupId>
 			<artifactId>query-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -42,6 +48,11 @@
 			<groupId>io.holoinsight.server</groupId>
 			<artifactId>extension-storage</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.holoinsight.server</groupId>
+			<artifactId>common-dao</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/server/server-parent/pom.xml
+++ b/server/server-parent/pom.xml
@@ -105,6 +105,13 @@
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
+
+			<dependency>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>okhttp</artifactId>
+				<version>4.1.1</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #97

# Rationale for this change
CeresDB is a high-performance, distributed, schema-less, cloud native time-series database that can handle both time-series and analytics workloads. So we decided to support CeresDB as a metric storage.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
support CeresDB metrics storage
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
