### PR TITLE
feat(home): use cron trigger in alarm scheduling 

### DIFF
--- a/server/home/home-alert/pom.xml
+++ b/server/home/home-alert/pom.xml
@@ -41,16 +41,12 @@
             <artifactId>home-service</artifactId>
             <version>${project.version}</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>io.holoinsight.server</groupId>-->
-<!--            <artifactId>home-grpc</artifactId>-->
-<!--            <version>${project.version}</version>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>net.devh</groupId>-->
-<!--            <artifactId>grpc-server-spring-boot-starter</artifactId>-->
-<!--            <version>2.13.1.RELEASE</version>-->
-<!--        </dependency>-->
+
+        <!-- schedule -->
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+        </dependency>
 
 
         <!-- COMMON -->

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
@@ -47,7 +47,7 @@ public class AlertNotify {
 
   private Map<String/* notify type */, List<String>> userNotifyMap; // 用户信息和通知渠道
 
-  private List<String> dingdingUrl; // 钉钉群
+  private List<WebhookInfo> dingdingUrl; // 钉钉群
 
   private List<WebhookInfo> webhookInfos; // 告警相关webhook消息
 

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotifyRequest.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotifyRequest.java
@@ -19,7 +19,7 @@ public class AlertNotifyRequest {
 
   private Map<String/* notify type */, List<String>> userNotifyMap; // 用户信息和通知渠道
 
-  private List<String> dingdingUrls; // 钉钉群
+  private List<WebhookInfo> dingdingUrls; // 钉钉群
 
   private List<WebhookInfo> webhookInfos; // 告警相关webhook消息
 

--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/exception/HoloinsightAlertInternalException.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/exception/HoloinsightAlertInternalException.java
@@ -19,4 +19,8 @@ public class HoloinsightAlertInternalException extends RuntimeException {
   public HoloinsightAlertInternalException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  public HoloinsightAlertInternalException(Throwable cause) {
+    super(cause);
+  }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #111 

# Rationale for this change
 
[Quartz Scheduler](https://github.com/quartz-scheduler/quartz) was used to schedule alarm tasks, cron was used to trigger them, and the scheduling rate was maintained as before.  

# What changes are included in this PR?

`server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/task/AlertTaskScheduler.java` was refactored.

# Are there any user-facing changes?

The alarm notification is delivered accurately in the first second of each minute. 

# How does this change test

Validation in a test environment.
