### PR TITLE
fix(home): fix PropertiesListener startup order

### DIFF
--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/config/PropertiesListener.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/config/PropertiesListener.java
@@ -4,8 +4,8 @@
 package io.holoinsight.server.home.web.config;
 
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.boot.env.EnvironmentPostProcessorApplicationListener;
 import org.springframework.context.ApplicationListener;
-import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.ConfigurableEnvironment;
 
@@ -16,7 +16,8 @@ import lombok.extern.slf4j.Slf4j;
  * @author jsy1001de
  * @version 1.0: PropertiesListener.java, v 0.1 2022年02月25日 10:10 上午 jinsong.yjs Exp $
  */
-@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+// This listener depends on EnvironmentPostProcessorApplicationListener
+@Order(EnvironmentPostProcessorApplicationListener.DEFAULT_ORDER + 10)
 @Slf4j
 @Deprecated
 public class PropertiesListener
@@ -24,7 +25,6 @@ public class PropertiesListener
 
   @Override
   public void onApplicationEvent(ApplicationEnvironmentPreparedEvent e) {
-
     ConfigurableEnvironment environment = e.getEnvironment();
     CipherUtils.setSeed(environment.getRequiredProperty("crypto.client.key"));
   }


### PR DESCRIPTION
# Rationale for this change
PropertiesListener depends on EnvironmentPostProcessorApplicationListener. But them have same Spring Order.
So their start sequence is random. This can cause a startup exception.

# What changes are included in this PR?
set PropertiesListener order to EnvironmentPostProcessorApplicationListener.DEFAULT_ORDER + 10

# Are there any user-facing changes?
no

# How does this change test
local test
