### PR TITLE
fix(query): fix query bootstrap error

### DIFF
--- a/server/query/query-bootstrap/pom.xml
+++ b/server/query/query-bootstrap/pom.xml
@@ -40,6 +40,12 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.holoinsight.server</groupId>
+			<artifactId>extension-storage-ceresdbx</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/server/query/query-bootstrap/src/test/resources/config/application-test.yaml
+++ b/server/query/query-bootstrap/src/test/resources/config/application-test.yaml
@@ -7,3 +7,8 @@ spring:
 cloudmonitor:
   storage:
     address: http://11.158.167.57:8082
+
+holoinsight:
+  metric:
+    storage:
+      type: "ceresdbx"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #130 

# Rationale for this change
Fix query bootstrap error

# What changes are included in this PR?
Add 'extension-storage-ceresdbx' dependency to query-bootstrap module.
In order to enable 'ceresdbx' storage, users need to configure 'holoinsight.metric.storage.type=ceresdbx' application property.

# Are there any user-facing changes?
No

# How does this change test
Local test

