### PR TITLE
fix(home): fix webhook message encode charset

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/common/webhook/WebhookUtil.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/common/webhook/WebhookUtil.java
@@ -12,7 +12,10 @@ import io.holoinsight.server.home.alert.model.event.WebhookInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author wangsiyuan
@@ -21,6 +24,8 @@ import java.util.Map;
 public class WebhookUtil {
 
   private static Logger LOGGER = LoggerFactory.getLogger(WebhookUtil.class);
+
+  private static final String CONTENT_TYPE_UTF_8 = "application/json; charset=utf-8";
 
   /**
    * 发送webhook消息
@@ -34,25 +39,25 @@ public class WebhookUtil {
       switch (webhookInfo.getRequestType().toUpperCase()) {
         case "POST":
           xHttpRequest = XHttpRequest.post(webhookInfo.getRequestUrl(),
-              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000,
-              webhookInfo.getWebhookMsg().getBytes(), "UTF_8");
+              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000,
+              webhookInfo.getWebhookMsg().getBytes(UTF_8), CONTENT_TYPE_UTF_8);
           break;
         case "GET":
           xHttpRequest = XHttpRequest.get(webhookInfo.getRequestUrl(), null,
-              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000);
+              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000);
           break;
         case "PUT":
           xHttpRequest = XHttpRequest.put(webhookInfo.getRequestUrl(),
-              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF_8", null, "UTF-8",
-              60000);
+              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), null,
+              CONTENT_TYPE_UTF_8, 60000);
           break;
         case "DELETE":
           xHttpRequest = XHttpRequest.delete(webhookInfo.getRequestUrl(),
-              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000);
+              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000);
           break;
         default:
           xHttpRequest = XHttpRequest.get(webhookInfo.getRequestUrl(), null,
-              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000);
+              G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000);
       }
       return HttpProxy.request(xHttpRequest);
     } catch (Exception e) {
@@ -66,25 +71,25 @@ public class WebhookUtil {
     switch (webhookInfo.getRequestType().toUpperCase()) {
       case "POST":
         xHttpRequest = XHttpRequest.post(webhookInfo.getRequestUrl(),
-            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000,
-            webhookInfo.getWebhookMsg().getBytes(), "UTF_8");
+            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000,
+            webhookInfo.getWebhookMsg().getBytes(UTF_8), CONTENT_TYPE_UTF_8);
         break;
       case "GET":
         xHttpRequest = XHttpRequest.get(webhookInfo.getRequestUrl(), null,
-            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000);
+            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000);
         break;
       case "PUT":
         xHttpRequest = XHttpRequest.put(webhookInfo.getRequestUrl(),
-            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF_8", null, "UTF-8",
-            60000);
+            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), null,
+            CONTENT_TYPE_UTF_8, 60000);
         break;
       case "DELETE":
         xHttpRequest = XHttpRequest.delete(webhookInfo.getRequestUrl(),
-            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000);
+            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000);
         break;
       default:
         xHttpRequest = XHttpRequest.get(webhookInfo.getRequestUrl(), null,
-            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), "UTF-8", 60000);
+            G.get().fromJson(webhookInfo.getRequestHeaders(), Map.class), UTF_8.name(), 60000);
     }
     return HttpProxy.request(xHttpRequest);
   }

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/NotifyChain.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/NotifyChain.java
@@ -47,7 +47,10 @@ public class NotifyChain extends ChainPlugin implements Runnable {
     for (int i = start; i < chains.size(); i++) {
       try {
         ChainPlugin plugin = this.chains.get(i);
-        plugin.input(this.input, this.context);
+        boolean success = plugin.input(this.input, this.context);
+        if (!success) {
+          break;
+        }
         if (plugin instanceof WaitPlugin) {
           // 遇到 wait 插件，放入调度队列，完成本次调度
           if (this.scheduleQueue == null) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #137 

# Rationale for this change
 
Specify `UTF-8` in string.getByte.

# What changes are included in this PR?


# Are there any user-facing changes?

The msg sent by webhook will be forced to encode in UTF-8.

# How does this change test

