### PR TITLE
fix: repeat call sendError() in filters

### DIFF
--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/util/scope/RequestContext.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/util/scope/RequestContext.java
@@ -23,14 +23,16 @@ public class RequestContext {
   }
 
   public static String getTrace() {
-    if (null == gs.get())
-      return "-";
-
-    Context context = gs.get();
     StringBuilder builder = new StringBuilder();
     builder.append("trace").append(",");
+    if (null == gs.get()) {
+      builder.append("-").append(",");
+      return builder.toString();
+    }
 
-    if (null != context.ms) {
+    Context context = gs.get();
+
+    if (null != context && null != context.ms) {
       builder.append("tenant=").append(null == RequestContext.getContext().ms.tenant ? "-"
           : RequestContext.getContext().ms.tenant).append(",");
 

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step2IdentityFilter.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step2IdentityFilter.java
@@ -63,7 +63,6 @@ public class Step2IdentityFilter implements Filter {
   }
 
   public boolean identity(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-
     // token 降级
     String token = req.getHeader("apiToken");
     if (StringUtil.isNotBlank(token)) {
@@ -116,17 +115,17 @@ public class Step2IdentityFilter implements Filter {
         req.setAttribute(MonitorUser.MONITOR_USER, user);
         return true;
       }
-      if (!resp.isCommitted())
+      if (!resp.isCommitted()) {
         resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+      }
     } catch (Throwable e) {
       try {
         log.error("login failed", e);
-        resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "login failed");
       } catch (Throwable e1) {
         log.error("login failed and senderror fail", e);
       }
     }
-
     return false;
 
   }

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step3AuthFilter.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step3AuthFilter.java
@@ -118,13 +118,14 @@ public class Step3AuthFilter implements Filter {
       if (null == ma || CollectionUtils.isEmpty(ma.powerConstants)
           || CollectionUtils.isEmpty(ma.getTenantViewPowerList())) {
         log.error("check tenant auth failed, " + J.toJson(ma));
-        resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "check tenant auth failed");
         return false;
       }
 
       if (!ma.getTenantViewPowerList().containsKey(ms.getTenant())) {
         log.error("check tenant " + ms.getTenant() + " is not auth, " + J.toJson(ma));
-        resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        resp.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+            "check tenant " + ms.getTenant() + " is not auth");
         return false;
       }
 

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step4AccessLogFilter.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step4AccessLogFilter.java
@@ -66,11 +66,7 @@ public class Step4AccessLogFilter implements Filter {
       logger.error(e.getMessage(), e);
     }
     StringBuilder builder = new StringBuilder();
-    builder.append("tenant=").append(
-        null == RequestContext.getContext().ms.tenant ? "-" : RequestContext.getContext().ms.tenant)
-        .append(",");
-    builder.append("accessKey=").append(null == RequestContext.getContext().ms.accessKey ? "-"
-        : RequestContext.getContext().ms.accessKey).append(",");
+    builder.append(RequestContext.getTrace());
     builder.append("client=").append(client == null ? "-" : client).append(",");
     builder.append("path=").append(path == null ? "-" : urlFormat(path)).append(",");
     builder.append("method=").append(method == null ? "-" : method).append(",");


### PR DESCRIPTION
# Which issue does this PR close?

Closes #161 

# Rationale for this change
 
When non-webapi external requests (like '/internal/api/gateway/agent/configuration/query'), key information such as apikey/tenant is not carried，at this point, npe will appear when going through step4AccessLogFilter ,

The step3AuthFilter filter will catch this exception，and then execute

> resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "auth check error, " + e.getMessage());

> log.error("{} auth check error, auth info: {}", RequestContext.getTrace(), J.toJson(J.toJson(RequestContext.getContext())), e);

But fininal also throws exception because of the npe and catch by step2IdentityFilter

> resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, RequestContext.getTrace() + " identity error, " + e.getMessage());

![image](https://user-images.githubusercontent.com/12846988/222053639-2911aa6b-8e20-4c83-90aa-17157f843fab.png)




# What changes are included in this PR?

Verify the npe in tracelog in step4AccessLogFilter，and then resolve this problem


# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
