### PR TITLE
fix(home): fix dingtalk notification template

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
@@ -152,7 +152,7 @@ public class AlertNotify {
     TemplateValue templateValue = new TemplateValue();
     templateValue.setRuleName(alertNotify.getRuleName());
     templateValue.setAlarmTime(sdf.format(day));
-    templateValue.setAlarmLevel(AlertLevel.getDesc(alertNotify.getAlarmLevel()));
+    templateValue.setAlarmLevel(AlertLevel.getByCode(alertNotify.getAlarmLevel()));
     templateValues.add(templateValue);
     return templateValues;
   }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/NotificationTemplate.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/NotificationTemplate.java
@@ -51,8 +51,8 @@ public class NotificationTemplate {
     template.fieldMap.put("此次评估触发时间", AlertTemplateField.alarmTime);
     // template.fieldMap.put("告警触发条件", AlertTemplateField.ALERT_TRIGGER_CONDITION);
     template.fieldMap.put("告警触发数值", AlertTemplateField.ALERT_VALUE);
-//    template.fieldMap.put("[详情]", AlertTemplateField.LINK);
-//    template.fieldMap.put("[设置]", AlertTemplateField.ruleUrl);
+    // template.fieldMap.put("[详情]", AlertTemplateField.LINK);
+    // template.fieldMap.put("[设置]", AlertTemplateField.ruleUrl);
 
     return template;
   }
@@ -154,10 +154,10 @@ public class NotificationTemplate {
         return templateValue.alertServer;
       case ALERT_ATTACHMENTS:
         return buildAttachments();
-//      case LINK:
-//        return link;
-//      case ruleUrl:
-//        return templateValue.ruleUrl;
+      // case LINK:
+      // return link;
+      // case ruleUrl:
+      // return templateValue.ruleUrl;
       case TENANT:
       case tenant:
         return templateValue.tenant;

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/NotificationTemplate.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/NotificationTemplate.java
@@ -51,8 +51,8 @@ public class NotificationTemplate {
     template.fieldMap.put("此次评估触发时间", AlertTemplateField.alarmTime);
     // template.fieldMap.put("告警触发条件", AlertTemplateField.ALERT_TRIGGER_CONDITION);
     template.fieldMap.put("告警触发数值", AlertTemplateField.ALERT_VALUE);
-    template.fieldMap.put("[详情]", AlertTemplateField.LINK);
-    template.fieldMap.put("[设置]", AlertTemplateField.ruleUrl);
+//    template.fieldMap.put("[详情]", AlertTemplateField.LINK);
+//    template.fieldMap.put("[设置]", AlertTemplateField.ruleUrl);
 
     return template;
   }
@@ -87,14 +87,14 @@ public class NotificationTemplate {
     return msg.toString();
   }
 
-  public Map<String, String> getTemplateMap(TemplateValue templateValue, String link) {
+  public Map<String, String> getTemplateMap(TemplateValue templateValue) {
     if (CollectionUtils.isEmpty(fieldMap)) {
       return Collections.emptyMap();
     }
     Map<String, String> result = new HashMap<>();
     for (Map.Entry<String, AlertTemplateField> entry : this.fieldMap.entrySet()) {
       AlertTemplateField field = entry.getValue();
-      String value = getValue(templateValue, field, link);
+      String value = getValue(templateValue, field);
       if (value == null) {
         value = StringUtils.EMPTY;
       }
@@ -103,7 +103,7 @@ public class NotificationTemplate {
     return result;
   }
 
-  private String getValue(TemplateValue templateValue, AlertTemplateField field, String link) {
+  private String getValue(TemplateValue templateValue, AlertTemplateField field) {
     switch (field) {
       case ALERT_TRACE_ID:
         return templateValue.alarmTraceId;
@@ -118,7 +118,7 @@ public class NotificationTemplate {
         return templateValue.metric;
       case ALERT_PRIORITY:
       case alarmLevel:
-        return templateValue.alarmLevel;
+        return templateValue.alarmLevel.getDesc();
       case ALERT_QUERY:
         return templateValue.alertQuery;
       case ALERT_SCOPE:
@@ -154,10 +154,10 @@ public class NotificationTemplate {
         return templateValue.alertServer;
       case ALERT_ATTACHMENTS:
         return buildAttachments();
-      case LINK:
-        return link;
-      case ruleUrl:
-        return templateValue.ruleUrl;
+//      case LINK:
+//        return link;
+//      case ruleUrl:
+//        return templateValue.ruleUrl;
       case TENANT:
       case tenant:
         return templateValue.tenant;

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/TemplateValue.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/TemplateValue.java
@@ -4,6 +4,7 @@
 package io.holoinsight.server.home.facade;
 
 import io.holoinsight.server.common.J;
+import io.holoinsight.server.home.facade.emuns.AlertLevel;
 import io.holoinsight.server.home.facade.trigger.DataSource;
 import io.holoinsight.server.home.facade.trigger.Trigger;
 import lombok.Data;
@@ -37,7 +38,7 @@ public class TemplateValue {
 
   String metric; // 监控项
 
-  String alarmLevel; // 告警级别
+  AlertLevel alarmLevel; // 告警级别
 
   String alarmTags; // 告警对象
 

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/AlertLevel.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/AlertLevel.java
@@ -28,6 +28,15 @@ public enum AlertLevel {
     return null;
   }
 
+  public static AlertLevel getByCode(String code) {
+    for (AlertLevel a : AlertLevel.values()) {
+      if (a.getCode().equals(code)) {
+        return a;
+      }
+    }
+    return null;
+  }
+
   public String getDesc() {
     return desc;
   }

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmWebhookFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmWebhookFacadeImpl.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.holoinsight.server.home.web.common.TokenUrls;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
@@ -52,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequestMapping("/webapi/alarmWebhook")
+@TokenUrls("/webapi/alarmWebhook/test")
 public class AlarmWebhookFacadeImpl extends BaseFacade {
 
   @Autowired


### PR DESCRIPTION
# Rationale for this change
 
- Remove rule url and monitor link from markdown alert content, instead of actionCard button.
- Keep AlertLevel enum type in `TemplateValue`.

# Are there any user-facing changes?

None.

# How does this change test

e2e