### PR TITLE
fix: replace IPAddressUtil with Apache commons-validator

### DIFF
--- a/server/common/common/pom.xml
+++ b/server/common/common/pom.xml
@@ -47,6 +47,10 @@
 			<artifactId>commons-codec</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-validator</groupId>
+			<artifactId>commons-validator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>

--- a/server/common/common/src/main/java/io/holoinsight/server/common/AddressUtil.java
+++ b/server/common/common/src/main/java/io/holoinsight/server/common/AddressUtil.java
@@ -5,7 +5,7 @@ package io.holoinsight.server.common;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import sun.net.util.IPAddressUtil;
+import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -58,8 +58,8 @@ public class AddressUtil {
           InetAddress nextElement = addresss.nextElement();
           String hostAddress = nextElement.getHostAddress();
           boolean isLoopAddress = nextElement.isLoopbackAddress();
-          boolean isIPV4 = IPAddressUtil.isIPv4LiteralAddress(hostAddress);
-          boolean isIPV6 = IPAddressUtil.isIPv6LiteralAddress(hostAddress);
+          boolean isIPV4 = InetAddressValidator.getInstance().isValidInet4Address(hostAddress);
+          boolean isIPV6 = InetAddressValidator.getInstance().isValidInet6Address(hostAddress);
 
           if (isIPV4 && !isIPV6) {
             localHostIPV4Lists.add(hostAddress);

--- a/server/holoinsight-dependencies/pom.xml
+++ b/server/holoinsight-dependencies/pom.xml
@@ -120,6 +120,10 @@
 				<version>3.12.0</version>
 			</dependency>
 			<dependency>
+				<groupId>commons-validator</groupId>
+				<artifactId>commons-validator</artifactId>
+				<version>1.7</version>
+			</dependency>			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>jsr305</artifactId>
 				<version>3.0.2</version>

--- a/server/holoinsight-dependencies/pom.xml
+++ b/server/holoinsight-dependencies/pom.xml
@@ -123,7 +123,8 @@
 				<groupId>commons-validator</groupId>
 				<artifactId>commons-validator</artifactId>
 				<version>1.7</version>
-			</dependency>			<dependency>
+			</dependency>
+			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>jsr305</artifactId>
 				<version>3.0.2</version>


### PR DESCRIPTION
# What changes are included in this PR?
Replace IPAddressUtil with Apache commons-validator, because sun.* packages has been removed from jdk 11
It's introduce a new package: commons-validator, if anyone concerned about it, can simply remove it and copy 2 files from source

# Are there any user-facing changes?
No

# How does this change test
No tests