### PR TITLE
feat: supports building amd64/arm64v8 converged image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,30 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Build docker image
+
+on:
+  pull_request_target:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+    - name: Init docker buildx
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
+    - name: Init docker buildx
+      run: sh ./scripts/docker/buildx.sh

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,9 +1,10 @@
-FROM openjdk:8 as openjdk
+FROM azul/zulu-openjdk:8 as jdk
+# azul/zulu-openjdk is active and supports amd64 and arm64v8
 
 FROM centos:7
 
 # install jdk8
-COPY --from=openjdk /usr/local/openjdk-8 /opt/java8
+COPY --from=jdk /usr/lib/jvm/zulu8 /opt/java8
 
 # add admin user
 RUN groupadd --gid 500 admin && \

--- a/scripts/docker/buildx.sh
+++ b/scripts/docker/buildx.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+cd `dirname $0`/../..
+project_root=`pwd`
+
+sh ./scripts/all-in-one/build.sh
+
+buildx_bin=""
+
+if docker buildx >/dev/null 2>&1; then
+  buildx_bin='docker buildx'
+else
+  tochecks=("$HOME/.docker/cli-plugins" /usr/local/lib/docker/cli-plugins /usr/local/libexec/docker/cli-plugins /usr/lib/docker/cli-plugins /usr/libexec/docker/cli-plugins)
+
+  for tocheck in ${tochecks[@]}; do
+    if [ -e "$tocheck/buildx" ]; then
+      buildx_bin="$tocheck/buildx"
+      break
+    fi
+  done
+fi
+
+if [ -z "$buildx_bin" ]; then
+  echo Please install buildx before running this script.
+  echo Check https://docs.docker.com/build/install-buildx/
+  exit 1
+fi
+
+echo use $buildx_bin
+
+# TODO update tag
+tag="temp"
+
+$buildx_bin build --platform linux/amd64 -t holoinsight/server:$tag-amd64-linux -f ./scripts/docker/Dockerfile .
+$buildx_bin build --platform linux/arm64/v8 -t holoinsight/server:$tag-arm64v8-linux -f ./scripts/docker/Dockerfile .
+
+
+# You need to change the tag and push these images to Docker Hub manually
+# docker push holoinsight/server:$tag-amd64-linux
+# docker push holoinsight/server:$tag-arm64v8-linux
+
+# And then create a manifest
+# See https://docs.docker.com/engine/reference/commandline/manifest/
+# docker manifest create holoinsight/server:$tag\
+#   -a holoinsight/server:$tag-amd64-linux \
+#   -a holoinsight/server:$tag-arm64v8-linux
+#
+# docker manifest push holoinsight/server:$tag


### PR DESCRIPTION
# Which issue does this PR close?

Closes #173 

# Rationale for this change
Supports building amd64/arm64v8 converged image using docker buildx.

# What changes are included in this PR?
Supports building amd64/arm64v8 converged image using docker buildx.

# Are there any user-facing changes?

# How does this change test
Build successfully in my M1 Mac and Linux.

```plain
#sh ./scripts/docker/buildx.sh
use /root/.docker/cli-plugins/buildx
[+] Building 0.9s (31/31) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 32B                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/centos:7                                                                                                                   0.7s
 => [internal] load metadata for docker.io/azul/zulu-openjdk:8                                                                                                                0.0s
 => [jdk 1/1] FROM docker.io/azul/zulu-openjdk:8                                                                                                                              0.0s
 => [internal] load build context                                                                                                                                             0.1s
 => => transferring context: 2.84kB                                                                                                                                           0.0s
 => [stage-1  1/24] FROM docker.io/library/centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4                                                   0.0s
 => CACHED [stage-1  2/24] COPY --from=jdk /usr/lib/jvm/zulu8 /opt/java8                                                                                                      0.0s
 => CACHED [stage-1  3/24] RUN groupadd --gid 500 admin &&   useradd admin -s /bin/bash --uid 500 --gid 500 -G root                                                           0.0s
 => CACHED [stage-1  4/24] RUN ln -s /opt/java8 /usr/local/java                                                                                                               0.0s
 => CACHED [stage-1  5/24] RUN ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime &&   yum -y install epel-release && yum install -y sudo net-tools iproute dstat whic  0.0s
 => CACHED [stage-1  6/24] RUN wget -qO /opt/arthas.zip https://arthas.aliyun.com/download/latest_version?mirror=aliyun &&     unzip -d /opt/arthas /opt/arthas.zip >/dev/nu  0.0s
 => CACHED [stage-1  7/24] COPY scripts/docker/sc /usr/local/bin/                                                                                                             0.0s
 => CACHED [stage-1  8/24] COPY scripts/docker/ensure_supervisord.sh /usr/local/bin/                                                                                          0.0s
 => CACHED [stage-1  9/24] COPY scripts/docker/supervisord.conf /etc/supervisord.conf                                                                                         0.0s
 => CACHED [stage-1 10/24] RUN echo 'export LANG=zh_CN.UTF-8' >> /etc/profile &&   echo 'LC_ALL=zh_CN.UTF-8' >> /etc/profile &&   echo 'PS1="\n\e[1;37m[\e[m\e[1;32m\u\e[m\e  0.0s
 => CACHED [stage-1 11/24] COPY scripts/docker/bin/app.ini /etc/supervisord.d/app.ini                                                                                         0.0s
 => CACHED [stage-1 12/24] RUN true                                                                                                                                           0.0s
 => CACHED [stage-1 13/24] COPY --chown=admin:admin scripts/docker/bin/*.sh /home/admin/bin/                                                                                  0.0s
 => CACHED [stage-1 14/24] RUN true                                                                                                                                           0.0s
 => CACHED [stage-1 15/24] COPY scripts/docker/entrypoint.sh /entrypoint.sh                                                                                                   0.0s
 => CACHED [stage-1 16/24] RUN true                                                                                                                                           0.0s
 => CACHED [stage-1 17/24] RUN chown -R admin:admin /home/admin                                                                                                               0.0s
 => CACHED [stage-1 18/24] WORKDIR /home/admin                                                                                                                                0.0s
 => CACHED [stage-1 19/24] COPY scripts/api /home/admin/api                                                                                                                   0.0s
 => CACHED [stage-1 20/24] COPY scripts/docker/nginx.conf /etc/nginx/nginx.conf                                                                                               0.0s
 => CACHED [stage-1 21/24] COPY scripts/docker/dist.zip /home/admin/dist.zip                                                                                                  0.0s
 => CACHED [stage-1 22/24] RUN unzip -d /home/admin/holoinsight-server-static/ /home/admin/dist.zip                                                                           0.0s
 => CACHED [stage-1 23/24] COPY --chown=admin:admin server/all-in-one/all-in-one-bootstrap/target/holoinsight-server.jar /home/admin/app.jar                                  0.0s
 => CACHED [stage-1 24/24] RUN echo `date` > /home/admin/build-time                                                                                                           0.0s
 => exporting to image                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                       0.0s
 => => writing image sha256:93615c15a262ced9ca3bfab0a3261780d9ffe39378ed6e3938f987378f55acaf                                                                                  0.0s
 => => naming to docker.io/holoinsight/server:test-amd64-linux                                                                                                                0.0s
[+] Building 0.9s (31/31) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 32B                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/centos:7                                                                                                                   0.0s
 => [internal] load metadata for docker.io/azul/zulu-openjdk:8                                                                                                                0.7s
 => [jdk 1/1] FROM docker.io/azul/zulu-openjdk:8@sha256:c732e7f24fceef589c740a2b410e478100473b969461a89dd7c655e73d38b614                                                      0.0s
 => [internal] load build context                                                                                                                                             0.0s
 => => transferring context: 2.84kB                                                                                                                                           0.0s
 => [stage-1  1/24] FROM docker.io/library/centos:7                                                                                                                           0.0s
 => CACHED [stage-1  2/24] COPY --from=jdk /usr/lib/jvm/zulu8 /opt/java8                                                                                                      0.0s
 => CACHED [stage-1  3/24] RUN groupadd --gid 500 admin &&   useradd admin -s /bin/bash --uid 500 --gid 500 -G root                                                           0.0s
 => CACHED [stage-1  4/24] RUN ln -s /opt/java8 /usr/local/java                                                                                                               0.0s
 => CACHED [stage-1  5/24] RUN ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime &&   yum -y install epel-release && yum install -y sudo net-tools iproute dstat whic  0.0s
 => CACHED [stage-1  6/24] RUN wget -qO /opt/arthas.zip https://arthas.aliyun.com/download/latest_version?mirror=aliyun &&     unzip -d /opt/arthas /opt/arthas.zip >/dev/nu  0.0s
 => CACHED [stage-1  7/24] COPY scripts/docker/sc /usr/local/bin/                                                                                                             0.0s
 => CACHED [stage-1  8/24] COPY scripts/docker/ensure_supervisord.sh /usr/local/bin/                                                                                          0.0s
 => CACHED [stage-1  9/24] COPY scripts/docker/supervisord.conf /etc/supervisord.conf                                                                                         0.0s
 => CACHED [stage-1 10/24] RUN echo 'export LANG=zh_CN.UTF-8' >> /etc/profile &&   echo 'LC_ALL=zh_CN.UTF-8' >> /etc/profile &&   echo 'PS1="\n\e[1;37m[\e[m\e[1;32m\u\e[m\e  0.0s
 => CACHED [stage-1 11/24] COPY scripts/docker/bin/app.ini /etc/supervisord.d/app.ini                                                                                         0.0s
 => CACHED [stage-1 12/24] RUN true                                                                                                                                           0.0s
 => CACHED [stage-1 13/24] COPY --chown=admin:admin scripts/docker/bin/*.sh /home/admin/bin/                                                                                  0.0s
 => CACHED [stage-1 14/24] RUN true                                                                                                                                           0.0s
 => CACHED [stage-1 15/24] COPY scripts/docker/entrypoint.sh /entrypoint.sh                                                                                                   0.0s
 => CACHED [stage-1 16/24] RUN true                                                                                                                                           0.0s
 => CACHED [stage-1 17/24] RUN chown -R admin:admin /home/admin                                                                                                               0.0s
 => CACHED [stage-1 18/24] WORKDIR /home/admin                                                                                                                                0.0s
 => CACHED [stage-1 19/24] COPY scripts/api /home/admin/api                                                                                                                   0.0s
 => CACHED [stage-1 20/24] COPY scripts/docker/nginx.conf /etc/nginx/nginx.conf                                                                                               0.0s
 => CACHED [stage-1 21/24] COPY scripts/docker/dist.zip /home/admin/dist.zip                                                                                                  0.0s
 => CACHED [stage-1 22/24] RUN unzip -d /home/admin/holoinsight-server-static/ /home/admin/dist.zip                                                                           0.0s
 => CACHED [stage-1 23/24] COPY --chown=admin:admin server/all-in-one/all-in-one-bootstrap/target/holoinsight-server.jar /home/admin/app.jar                                  0.0s
 => CACHED [stage-1 24/24] RUN echo `date` > /home/admin/build-time                                                                                                           0.0s
 => exporting to image                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                       0.0s
 => => writing image sha256:4b8f4f139c01c99990081b8fb3f219b582d9b35b3379159d2ea4b50fec17e731                                                                                  0.0s
 => => naming to docker.io/holoinsight/server:test-arm64v8-linux
```
