### PR TITLE
refactor: Quick Start demo supports docker compose v1.29 && v2

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -17,10 +17,19 @@ HoloInsight 是一个云原生可观察性平台，特别专注于实时日志�
 
 # 快速入门
 
-### 使用 docker-compose V2 部署
+### 使用 docker-compose 部署
 先决条件:
-1. 已安装 [docker](https://docs.docker.com/engine/install/) & [docker-compose V2](https://docs.docker.com/compose/install/other/)
+1. 已安装 [docker](https://docs.docker.com/engine/install/) & [docker-compose](https://docs.docker.com/compose/install/other/)(**>=v1.29 || >=v2**)
 2. 有 Linux 或 Mac 环境
+
+检查 `docker compose` 的版本：
+```bash
+# V1
+docker-compose version
+
+# V2
+docker compose version
+```
 
 > 可以参考附录里的 [安装-docker-compose](#安装-docker-compose).  
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ HoloInsight is a cloud-native observability platform with a special focus on rea
 
 # Quick Start
 
-### Deploy using docker-compose V2
+### Deploy using docker-compose
 Requirements:
-1. [docker](https://docs.docker.com/engine/install/) & [docker-compose V2](https://docs.docker.com/compose/install/other/) installed
+1. [docker](https://docs.docker.com/engine/install/) & [docker-compose](https://docs.docker.com/compose/install/other/)(**>=v1.29 || >=v2**) installed
 2. Linux or Mac environment 
 
+To verify whether docker compose is already installed:
+```bash
+# V1
+docker-compose version
 
-Follow the [guide](#install-docker-compose) in [appendix](#appendix) to install docker-compose quickly.
+# V2
+docker compose version
+```
+
+> Follow the [guide](#install-docker-compose) in [appendix](#appendix) to install docker-compose quickly.
 
 
 1. clone the repo

--- a/deploy/examples/docker-compose/docker-compose.sh
+++ b/deploy/examples/docker-compose/docker-compose.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+docker_compose_bin=
+
+if docker compose >/dev/null 2>&1; then
+  docker_compose_bin='docker compose'
+elif which docker-compose >/dev/null 2>&1; then
+  docker_compose_bin='docker-compose'
+fi
+
+if [ -z "$docker_compose_bin" ]; then
+  echo 'docker compose is required'
+  echo 'See https://docs.docker.com/compose/install/'
+  exit 1
+fi
+
+$docker_compose_bin "$@"

--- a/deploy/examples/docker-compose/docker-compose.yaml
+++ b/deploy/examples/docker-compose/docker-compose.yaml
@@ -10,8 +10,6 @@ services:
       MYSQL_DATABASE: holoinsight
     volumes:
     - ./my.cnf:/etc/mysql/conf.d/my.cnf
-    ports:
-    - 3305:3306
     restart: always
     healthcheck:
       test: mysql -uholoinsight -pholoinsight -Dholoinsight

--- a/deploy/examples/docker-compose/down.sh
+++ b/deploy/examples/docker-compose/down.sh
@@ -10,4 +10,4 @@ if [ "$mirror" = "cn" ]; then
   env_file=".env-cn"
 fi
 
-docker-compose --env-file $env_file down
+$script_dir/docker-compose.sh --env-file $env_file down

--- a/deploy/examples/docker-compose/up.sh
+++ b/deploy/examples/docker-compose/up.sh
@@ -23,9 +23,9 @@ if [ `uname` = "Darwin" ] && [ `uname -m` = "arm64" ]; then
   fi
 fi
 
-docker-compose --env-file $env_file up -d
+$script_dir/docker-compose.sh --env-file $env_file up -d
 
 echo holoinsight bootstrap successfully, please visit http://localhost:8080
 echo
-docker ps -a
+
 sh $script_dir/install-agent.sh


### PR DESCRIPTION
# Which issue does this PR close?

Closes #186

# Rationale for this change
The 'Quick Start' demo requires docker compose version >= v1. 29 || >=v2.
When use docker compose V1, the cli is 'docker-compose'.
When use docker compose V2, the cli is 'docker compose'.

# What changes are included in this PR?
Automatically use `docker compose` when docker compose V2 installed.
Automatically use `docker-compose` when docker compose V1 installed.

# Are there any user-facing changes?
No

# How does this change test
Local test

docker compose V1
![image](https://user-images.githubusercontent.com/8319940/222644061-1364e967-c16c-4dd7-b46f-f28a51f694dd.png)

docker compose v2
![image](https://user-images.githubusercontent.com/8319940/222645227-898b605c-74ed-4eb1-8009-0ddca01f86b6.png)
