### PR TITLE
feat: improve duration parsing

### DIFF
--- a/server/common/common/src/main/java/io/holoinsight/server/common/DurationUtil.java
+++ b/server/common/common/src/main/java/io/holoinsight/server/common/DurationUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.common;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.Duration;
+
+/**
+ * A tool for converting strings to durations with precision down to seconds
+ */
+public class DurationUtil {
+
+  /**
+   * Examples:
+   * 
+   * <pre>
+   *    "5s"       -- parses as "5 seconds"
+   *    "1m"       -- parses as "1 minute" (where a minute is 60 seconds)
+   *    "1h1m1s"   -- parses as "1 hour, 1 minute and 1 second"
+   *    "2w"       -- parses as "2 weeks"
+   *    "1M"       -- parses as "1 month" (the uppercase `M` stands for months and the lowercase `m` stands for minutes)
+   *    "1y"       -- parses as "1 year" (year is the maximum conversion precision)
+   *    "1"        -- java.lang.IllegalArgumentException: invalid duration: 1
+   * </pre>
+   */
+  public static Duration parse(String input) {
+    long secs = 0;
+    StringBuilder number = new StringBuilder();
+    StringBuilder letters = new StringBuilder();
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      if (Character.isDigit(c)) {
+        number.append(c);
+      } else if (Character.isLetter(c) && (number.length() > 0)) {
+        letters.append(c);
+        while (i + 1 < input.length() && Character.isLetter(input.charAt(i + 1))) {
+          letters.append(input.charAt(i + 1));
+          i++;
+        }
+        secs += toSecs(Integer.parseInt(number.toString()), letters.toString());
+        number = new StringBuilder();
+        letters = new StringBuilder();
+      }
+    }
+    if (secs <= 0 || number.length() > 0 || letters.length() > 0) {
+      throw new IllegalArgumentException("invalid duration: " + input);
+    }
+    return Duration.ofSeconds(secs);
+  }
+
+  private static long toSecs(int num, String unit) {
+
+    if (StringUtils.equalsIgnoreCase(unit, "y") || StringUtils.equalsIgnoreCase(unit, "year")) {
+      num *= 60 * 60 * 24 * 365;
+    } else if (StringUtils.equals(unit, "M") || StringUtils.equalsIgnoreCase(unit, "month")) {
+      num *= 60 * 60 * 24 * 30;
+    } else if (StringUtils.equalsIgnoreCase(unit, "w")
+        || StringUtils.equalsIgnoreCase(unit, "week")) {
+      num *= 60 * 60 * 24 * 7;
+    } else if (StringUtils.equalsIgnoreCase(unit, "d")
+        || StringUtils.equalsIgnoreCase(unit, "day")) {
+      num *= 60 * 60 * 24;
+    } else if (StringUtils.equalsIgnoreCase(unit, "h")
+        || StringUtils.equalsIgnoreCase(unit, "hour")) {
+      num *= 60 * 60;
+    } else if (StringUtils.equals(unit, "m") || StringUtils.equalsIgnoreCase(unit, "min")
+        || StringUtils.equalsIgnoreCase(unit, "minute")) {
+      num *= 60;
+    } else if (StringUtils.equalsIgnoreCase(unit, "s") || StringUtils.equalsIgnoreCase(unit, "sec")
+        || StringUtils.equalsIgnoreCase(unit, "second")) {
+      num *= 1;
+    } else {
+      num *= 0;
+    }
+    return num;
+  }
+}

--- a/server/common/common/src/test/java/io/holoinsight/server/common/DurationUtilTest.java
+++ b/server/common/common/src/test/java/io/holoinsight/server/common/DurationUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class DurationUtilTest {
+
+  @Test
+  public void testParse() {
+    Map<String, Long> validFormats = new HashMap<>();
+    validFormats.put("1s", 1000L);
+    validFormats.put("5S", 5 * 1000L);
+    validFormats.put("30second", 30 * 1000L);
+    validFormats.put("1m", 60 * 1000L);
+    validFormats.put("5MIN", 5 * 60 * 1000L);
+    validFormats.put("10minute", 10 * 60 * 1000L);
+    validFormats.put("1h", 60 * 60 * 1000L);
+    validFormats.put("20HOUR", 20 * 60 * 60 * 1000L);
+    validFormats.put("1d", 24 * 60 * 60 * 1000L);
+    validFormats.put("3DAY", 3 * 24 * 60 * 60 * 1000L);
+    validFormats.put("1week", 7 * 24 * 60 * 60 * 1000L);
+    validFormats.put("3w", 3 * 7 * 24 * 60 * 60 * 1000L);
+    validFormats.put("1M", 30 * 24 * 60 * 60 * 1000L);
+    validFormats.put("3month", 3 * 30 * 24 * 60 * 60 * 1000L);
+    validFormats.put("1year", 365 * 24 * 60 * 60 * 1000L);
+    validFormats.put("10year", 10 * 365 * 24 * 60 * 60 * 1000L);
+    validFormats.forEach((format, millis) -> {
+      Long actual = DurationUtil.parse(format).toMillis();
+      Assert.assertEquals(millis, actual);
+    });
+    Set<String> inValidFormats = new HashSet<>();
+    inValidFormats.add("5");
+    inValidFormats.add("d");
+    inValidFormats.add("0s");
+    inValidFormats.add("1mm");
+    inValidFormats.add("1h1");
+    inValidFormats.forEach(format -> {
+      Assert.assertThrows(IllegalArgumentException.class, () -> DurationUtil.parse(format));
+    });
+
+
+  }
+
+}

--- a/server/common/common/src/test/java/io/holoinsight/server/common/DurationUtilTest.java
+++ b/server/common/common/src/test/java/io/holoinsight/server/common/DurationUtilTest.java
@@ -36,13 +36,13 @@ public class DurationUtilTest {
       Long actual = DurationUtil.parse(format).toMillis();
       Assert.assertEquals(millis, actual);
     });
-    Set<String> inValidFormats = new HashSet<>();
-    inValidFormats.add("5");
-    inValidFormats.add("d");
-    inValidFormats.add("0s");
-    inValidFormats.add("1mm");
-    inValidFormats.add("1h1");
-    inValidFormats.forEach(format -> {
+    Set<String> invalidFormats = new HashSet<>();
+    invalidFormats.add("5");
+    invalidFormats.add("d");
+    invalidFormats.add("0s");
+    invalidFormats.add("1mm");
+    invalidFormats.add("1h1");
+    invalidFormats.forEach(format -> {
       Assert.assertThrows(IllegalArgumentException.class, () -> DurationUtil.parse(format));
     });
 

--- a/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/DefaultQueryServiceImpl.java
+++ b/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/DefaultQueryServiceImpl.java
@@ -5,6 +5,7 @@ package io.holoinsight.server.query.service.impl;
 
 import com.google.common.collect.Lists;
 import com.google.protobuf.MessageOrBuilder;
+import io.holoinsight.server.common.DurationUtil;
 import io.holoinsight.server.common.ProtoJsonUtils;
 import io.holoinsight.server.extension.MetricStorage;
 import io.holoinsight.server.extension.model.QueryMetricsParam;
@@ -388,7 +389,7 @@ public class DefaultQueryServiceImpl implements QueryService {
       List<QueryProto.Point.Builder> pointBuilders = resultBuilder.getPointsBuilderList();
       Map<Long, QueryProto.Point.Builder> timePointMap = new TreeMap<>(pointBuilders.stream()
           .collect(Collectors.toMap(QueryProto.Point.Builder::getTimestamp, Function.identity())));
-      long sample = QueryStorageUtils.convertDownSample(downsample);
+      long sample = DurationUtil.parse(downsample).toMillis();
       for (long period =
           start % sample == 0 ? start : start / sample * sample + sample; period <= end; period +=
               sample) {

--- a/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/QueryStorageUtils.java
+++ b/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/QueryStorageUtils.java
@@ -87,54 +87,6 @@ public class QueryStorageUtils {
     return param;
   }
 
-
-  public static long convertDownSample(String downsample) {
-
-    long sample = 1000;
-    switch (downsample) {
-      case "1s":
-        sample = 1000;
-        break;
-      case "5s":
-        sample = 5000;
-        break;
-      case "10s":
-        sample = 10000;
-        break;
-      case "30s":
-        sample = 30000;
-        break;
-      case "1min":
-      case "1m":
-        sample = 60000;
-        break;
-      case "5min":
-      case "5m":
-        sample = 60000 * 5;
-        break;
-      case "10min":
-      case "10m":
-        sample = 60000 * 10;
-        break;
-      case "30min":
-      case "30m":
-        sample = 60000 * 30;
-        break;
-      case "1hour":
-      case "1h":
-        sample = 60000 * 60;
-        break;
-      case "1day":
-      case "1d":
-        sample = 60000 * 60 * 24;
-        break;
-      default:
-        throw new IllegalArgumentException("unknown downsample: " + downsample);
-    }
-
-    return sample;
-  }
-
   public static Object convertFillPolocy(String fillPolicy) {
     Object fill = null;
     switch (fillPolicy) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #209 

# Rationale for this change
Improve the parsing of string formats such as `dawnsample` to duration.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Added a `DurationUtil` for parsing the duration of the string format.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Users can use more duration formats that were not supported before.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Unit test [DurationUtilTest](https://github.com/xiangwanpeng/holoinsight/blob/feat/duration-utils/server/common/common/src/test/java/io/holoinsight/server/common/DurationUtilTest.java) passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
