### PR TITLE
build: downgrade mongo version to 4.4.18 for better compatibility

### DIFF
--- a/deploy/examples/docker-compose/.env
+++ b/deploy/examples/docker-compose/.env
@@ -1,5 +1,5 @@
 mysql_image=mysql:8
-mongo_image=mongo:5
+ mongo_image=mongo:4.4.18
 ceresdb_image=ceresdb/ceresdb-server:v0.3.1
 server_image=holoinsight/server:latest
 agent_image=holoinsight/agent:latest

--- a/deploy/examples/docker-compose/.env-cn
+++ b/deploy/examples/docker-compose/.env-cn
@@ -1,5 +1,5 @@
 mysql_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/mysql:8
-mongo_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/mongo:5
+mongo_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/mongo:4.4.18
 ceresdb_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/ceresdb:v0.3.1
 server_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/server:latest
 agent_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/agent:latest

--- a/deploy/examples/docker-compose/up.sh
+++ b/deploy/examples/docker-compose/up.sh
@@ -15,8 +15,8 @@ if [ `uname` = "Darwin" ] && [ `uname -m` = "arm64" ]; then
   if [ "$1" = "cn" ]; then
     export server_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/server:latest-arm64v8
     export agent_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/agent:latest-arm64v8
-    export mysql_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/mysql:8-arm64v8
-    export mongo_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/mongo:5-arm64v8
+    export mysql_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/mysql:8
+    export mongo_image=registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/mongo:4.4.18
   else
     export server_image=holoinsight/server:latest-arm64v8
     export agent_image=holoinsight/agent:latest-arm64v8

--- a/deploy/examples/k8s/base/mongo.yaml
+++ b/deploy/examples/k8s/base/mongo.yaml
@@ -25,7 +25,9 @@ spec:
           name: mongo-cm
       containers:
       - name: mongo
-        image: mongo:5
+        # mongo with version >= v5 requires CPU AVX. So we use 4.4.18 is enough
+        # https://stackoverflow.com/questions/70818543/mongo-db-deployment-not-working-in-kubernetes-because-processor-doesnt-have-avx
+        image: mongo:4.4.18
         env:
         - name: MONGO_INITDB_ROOT_USERNAME
           value: admin

--- a/deploy/examples/k8s/overlays/example-cn/kustomization.yaml
+++ b/deploy/examples/k8s/overlays/example-cn/kustomization.yaml
@@ -11,7 +11,7 @@ images:
 - name: ceresdb/ceresdb-server
   newName: registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/ceresdb
 - name: gcr.io/cadvisor/cadvisor
-  newName: registry-vpc.cn-shanghai.aliyuncs.com/holoinsight/cadvisor
+  newName: registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/cadvisor
 - name: holoinsight/agent
   newName: registry.cn-hangzhou.aliyuncs.com/holoinsight-examples/agent
 - name: holoinsight/server


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
![image](https://user-images.githubusercontent.com/8319940/224017297-9a42b1bb-c3e9-4ad8-ba03-efd8c2fcc2d9.png)
Mongo 5 requires a CPU with AVX support, which leads to `Quick Start` deployment failure when running with a CPU without AVX support.

Check this stackoverflow question [Mongo DB deployment not working in kubernetes because processor doesn't have AVX support](https://stackoverflow.com/questions/70818543/mongo-db-deployment-not-working-in-kubernetes-because-processor-doesnt-have-avx)

# What changes are included in this PR?
Downgrade mongo version to 4.4.18 for better compatibility.

# Are there any user-facing changes?
No

# How does this change test
Tests 'Quick Start' successfully in Linux and M1 mac.
