### PR TITLE
build: use simple port healthcheck for better compatibility

### DIFF
--- a/deploy/examples/docker-compose/docker-compose.yaml
+++ b/deploy/examples/docker-compose/docker-compose.yaml
@@ -13,8 +13,9 @@ services:
     restart: always
     healthcheck:
       test: mysql -uholoinsight -pholoinsight -Dholoinsight
-      interval: 1s
+      interval: 5s
       retries: 300
+      timeout: 10s
   mongo:
     container_name: example-mongo-1
     image: ${mongo_image}
@@ -26,9 +27,10 @@ services:
     - ./init.js:/docker-entrypoint-initdb.d/init.js
     restart: always
     healthcheck:
-      test: mongosh
-      interval: 1s
+      test: ["CMD", "timeout", "1", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/27017"]
+      interval: 5s
       retries: 300
+      timeout: 10s
   ceresdb:
     container_name: example-ceresdb-1
     image: ${ceresdb_image}
@@ -36,9 +38,10 @@ services:
     - ./ceresdb_entrypoint.sh:/entrypoint.sh
     restart: always
     healthcheck:
-      test: curl localhost:5440
-      interval: 1s
+      test: ["CMD", "timeout", "1", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/5440"]
+      interval: 5s
       retries: 300
+      timeout: 10s
   mysql-data-init:
     container_name: example-mysql-data-init-1
     image: ${mysql_image}
@@ -61,7 +64,7 @@ services:
     image: ${server_image}
     pull_policy: always
     healthcheck:
-      test: sh /home/admin/bin/health.sh
+      test: ["CMD", "bash", "/home/admin/bin/health.sh"]
       interval: 1s
       retries: 300
     depends_on:

--- a/deploy/examples/k8s/overlays/example/wait-server.sh
+++ b/deploy/examples/k8s/overlays/example/wait-server.sh
@@ -10,4 +10,4 @@ echo
 kubectl -n $ns get pods -o wide
 
 echo [server] deploy successfully, visit holoinsight at http://localhost:8080
-kubectl -n $ns port-forward pod/holoinsight-server-example-0 8080:80
+kubectl -n $ns port-forward pod/holoinsight-server-example-0 --address 0.0.0.0 8080:80


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Mongo and CeresDB uses different healthcheck method.
For example:
1. CeresDB image contains `curl` luckily for healthcheck. If the image doesn't `curl` we have to use another method.
2. MongoDB 5 image contains a `mongosh` bin. We use it for healthcheck.
3. MongoDB 4 image doesn't contains a `mongosh`. So we have to use another healthcheck method.

They can actually use a unified and general healthcheck method. Port checking is enough for them.

# What changes are included in this PR?
Use simple port healthcheck for better compatibility, which is learning from [skywalking](https://github.com/apache/skywalking/blob/master/test/e2e-v2/cases/alarm/es/es-sharding/docker-compose.yml#L28)


# Are there any user-facing changes?
No

# How does this change test
Tests 'Quick Start' successfully in Linux and M1 mac.
