### PR TITLE
fix: solve problem that blacklist filtering for log monitoring does n…

### DIFF
--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
@@ -27,7 +27,6 @@ import io.holoinsight.server.registry.model.TimeParse;
 import io.holoinsight.server.registry.model.Where;
 import io.holoinsight.server.registry.model.Where.Contains;
 import io.holoinsight.server.registry.model.Where.ContainsAny;
-import io.holoinsight.server.registry.model.Where.NotIn;
 import io.holoinsight.server.registry.model.Where.Regexp;
 import io.holoinsight.server.registry.model.Window;
 import org.apache.commons.lang3.StringUtils;
@@ -266,6 +265,7 @@ public class GaeaSqlTaskUtil {
     if (!CollectionUtils.isEmpty(blackFilters)) {
       blackFilters.forEach(w -> {
         Where and = new Where();
+        Where not = new Where();
 
         Elect elect = new Elect();
         switch (splitType) {
@@ -276,11 +276,12 @@ public class GaeaSqlTaskUtil {
             leftRight.setRight(w.rule.right);
             elect.setType("leftRight");
             elect.setLeftRight(leftRight);
-            NotIn notIn = new NotIn();
-            notIn.setValues(w.values);
-            notIn.setElect(elect);
+            Where.In in = new Where.In();
+            in.setValues(w.values);
+            in.setElect(elect);
 
-            and.setNotIn(notIn);
+            not.setIn(in);
+            and.setNot(not);
             break;
           case contains:
             ContainsAny contains = new ContainsAny();
@@ -288,9 +289,7 @@ public class GaeaSqlTaskUtil {
             contains.setElect(elect);
             contains.setValues(w.values);
 
-            Where not = new Where();
             not.setContainsAny(contains);
-
             and.setNot(not);
             break;
           default:


### PR DESCRIPTION
…ot take effect

# Which issue does this PR close?

Closes #229 

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. use not->in expression, now holoinsight-agent does not support _notin_ expression
```
            {
              "not": {
                "in": {
                  "elect": {
                    "type": "leftRight",
                    "leftRight": {
                      "leftIndex": 12,
                      "left": "|",
                      "right": "|"
                    }
                  },
                  "values": [
                    "test"
                  ]
                }
              }
            }
```

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
