### PR TITLE
fix(home): fix alarm rule facade

### DIFF
--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlarmRuleDTO.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlarmRuleDTO.java
@@ -171,7 +171,7 @@ public class AlarmRuleDTO {
     return id == null;
   }
 
-  private static String getApmLink(AlarmRuleDTO alarmRuleDTO, String domain,
+  protected static String getApmLink(AlarmRuleDTO alarmRuleDTO, String domain,
       Map<String /* metric */, Map<String /* type */, String /* page */>> systemMetrics) {
     String app = alarmRuleDTO.sourceType.split("_")[1];
     String metric = alarmRuleDTO.getMetric();
@@ -180,6 +180,9 @@ public class AlarmRuleDTO {
       return StringUtils.EMPTY;
     }
     Map<String /* type */, String /* page */> pages = systemMetrics.get(metric);
+    if (CollectionUtils.isEmpty(pages)) {
+      return StringUtils.EMPTY;
+    }
     String type = isServer ? "server" : "app";
     String page = pages.get(type);
     return domain + page + "&app=" + app;

--- a/server/home/home-facade/src/test/java/io/holoinsight/server/home/facade/AlarmRuleDTOTest.java
+++ b/server/home/home-facade/src/test/java/io/holoinsight/server/home/facade/AlarmRuleDTOTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package io.holoinsight.server.home.facade;
+
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.home.facade.trigger.DataSource;
+import io.holoinsight.server.home.facade.trigger.Trigger;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.holoinsight.server.home.facade.AlarmRuleDTO.getApmLink;
+import static org.junit.Assert.*;
+
+/**
+ * @author masaimu
+ * @version 2023-03-14 18:30:00
+ */
+public class AlarmRuleDTOTest {
+
+  @Test
+  public void testGetApmLink() {
+    AlarmRuleDTO alarmRuleDTO = new AlarmRuleDTO();
+    alarmRuleDTO.setRule(buildRule("test_metric"));
+    alarmRuleDTO.setSourceType("apm_appName");
+    String domain = "http://testdomain/";
+    Map<String /* metric */, Map<String /* type */, String /* page */>> systemMetrics =
+        new HashMap<>();
+    systemMetrics.put("test_metric", Collections.singletonMap("server", "page"));
+    String link = getApmLink(alarmRuleDTO, domain, systemMetrics);
+    Assert.assertTrue(StringUtils.equals("http://testdomain/page&app=appName", link));
+
+    alarmRuleDTO.setRule(buildRule("fake_test_metric"));
+    link = getApmLink(alarmRuleDTO, domain, systemMetrics);
+    Assert.assertTrue(StringUtils.isEmpty(link));
+  }
+
+  private Map<String, Object> buildRule(String metric) {
+    Rule rule = new Rule();
+    rule.setTriggers(Arrays.asList(new Trigger()));
+    Trigger trigger = rule.getTriggers().get(0);
+    trigger.setDatasources(Arrays.asList(new DataSource()));
+    DataSource dataSource = trigger.getDatasources().get(0);
+    dataSource.setMetric(metric);
+    return J.toMap(J.toJson(rule));
+  }
+}

--- a/server/home/home-web/pom.xml
+++ b/server/home/home-web/pom.xml
@@ -53,5 +53,11 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmRuleFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmRuleFacadeImpl.java
@@ -69,13 +69,13 @@ import static io.holoinsight.server.home.facade.AlarmRuleDTO.tryParseLink;
 public class AlarmRuleFacadeImpl extends BaseFacade {
 
   @Autowired
-  private AlertRuleService alarmRuleService;
+  protected AlertRuleService alarmRuleService;
 
   @Autowired
-  private AlertSubscribeService alarmSubscribeService;
+  protected AlertSubscribeService alarmSubscribeService;
 
   @Autowired
-  private AlertGroupService alarmGroupService;
+  protected AlertGroupService alarmGroupService;
 
   @Autowired
   private AlarmHistoryService alarmHistoryService;
@@ -87,7 +87,7 @@ public class AlarmRuleFacadeImpl extends BaseFacade {
   private CustomPluginMapper customPluginMapper;
 
   @Resource
-  private AlarmRuleConverter alarmRuleConverter;
+  protected AlarmRuleConverter alarmRuleConverter;
 
   @Value("${holoinsight.home.domain}")
   private String domain;
@@ -362,7 +362,7 @@ public class AlarmRuleFacadeImpl extends BaseFacade {
     return result;
   }
 
-  private List<AlarmRuleDTO> getRuleListByGroup(boolean myself) {
+  protected List<AlarmRuleDTO> getRuleListByGroup(boolean myself) {
     String userId = RequestContext.getContext().mu.getUserId();
     List<AlarmGroupDTO> listByUserLike =
         alarmGroupService.getListByUserLike(userId, MonitorCookieUtil.getTenantOrException());
@@ -395,7 +395,9 @@ public class AlarmRuleFacadeImpl extends BaseFacade {
       QueryWrapper<AlarmRule> queryWrapper = new QueryWrapper<>();
       queryWrapper.in("id", ruleIds);
       if (myself) {
-        queryWrapper.and(wrapper -> wrapper.eq("creator", userId).or().eq("modifier", userId));
+        String loginName = RequestContext.getContext().mu.getLoginName();
+        queryWrapper
+            .and(wrapper -> wrapper.eq("creator", loginName).or().eq("modifier", loginName));
       }
       List<AlarmRule> alarmRules = alarmRuleService.list(queryWrapper);
       List<AlarmRuleDTO> byIds = this.alarmRuleConverter.dosToDTOs(alarmRules);
@@ -409,7 +411,7 @@ public class AlarmRuleFacadeImpl extends BaseFacade {
 
   }
 
-  private List<AlarmRuleDTO> getRuleListBySubscribe(boolean myself) {
+  protected List<AlarmRuleDTO> getRuleListBySubscribe(boolean myself) {
     String userId = RequestContext.getContext().mu.getUserId();
     Map<String, Object> conditions = new HashMap<>();
     conditions.put("subscriber", userId);
@@ -433,7 +435,8 @@ public class AlarmRuleFacadeImpl extends BaseFacade {
     QueryWrapper<AlarmRule> queryWrapper = new QueryWrapper<>();
     queryWrapper.in("id", ruleIds);
     if (myself) {
-      queryWrapper.and(wrapper -> wrapper.eq("creator", userId).or().eq("modifier", userId));
+      String loginName = RequestContext.getContext().mu.getLoginName();
+      queryWrapper.and(wrapper -> wrapper.eq("creator", loginName).or().eq("modifier", loginName));
     }
     List<AlarmRule> alarmRules = alarmRuleService.list(queryWrapper);
     return this.alarmRuleConverter.dosToDTOs(alarmRules);

--- a/server/home/home-web/src/test/java/io/holoinsight/server/home/web/controller/AlarmRuleFacadeImplTest.java
+++ b/server/home/home-web/src/test/java/io/holoinsight/server/home/web/controller/AlarmRuleFacadeImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.web.controller;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import io.holoinsight.server.home.biz.service.AlertGroupService;
+import io.holoinsight.server.home.biz.service.AlertRuleService;
+import io.holoinsight.server.home.biz.service.AlertSubscribeService;
+import io.holoinsight.server.home.common.util.scope.MonitorScope;
+import io.holoinsight.server.home.common.util.scope.MonitorUser;
+import io.holoinsight.server.home.common.util.scope.RequestContext;
+import io.holoinsight.server.home.dal.converter.AlarmRuleConverterImpl;
+import io.holoinsight.server.home.dal.model.AlarmRule;
+import io.holoinsight.server.home.dal.model.dto.AlarmGroupDTO;
+import io.holoinsight.server.home.dal.model.dto.AlarmSubscribeInfo;
+import io.holoinsight.server.home.facade.AlarmRuleDTO;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author masaimu
+ * @version 2023-03-14 21:29:00
+ */
+public class AlarmRuleFacadeImplTest {
+
+  AlarmRuleFacadeImpl facade;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+
+    facade = new AlarmRuleFacadeImpl();
+    facade.alarmGroupService = Mockito.mock(AlertGroupService.class);
+    facade.alarmSubscribeService = Mockito.mock(AlertSubscribeService.class);
+    facade.alarmRuleService = Mockito.mock(AlertRuleService.class);
+    facade.alarmRuleConverter = new AlarmRuleConverterImpl();
+    MonitorUser mu = new MonitorUser();
+    mu.setLoginName("test_loginName");
+    mu.setUserId("test_userId");
+    MonitorScope ms = new MonitorScope();
+    ms.tenant = "test_tenant";
+    RequestContext.Context context = new RequestContext.Context(ms, mu, null);
+    RequestContext.setContext(context);
+
+    AlarmGroupDTO alarmGroupDTO = new AlarmGroupDTO();
+    alarmGroupDTO.setId(111L);
+    AlarmSubscribeInfo alarmSubscribeInfo = new AlarmSubscribeInfo();
+    alarmSubscribeInfo.setUniqueId("rule_22222");
+
+    AlarmRule alarmRule = new AlarmRule();
+    alarmRule.setId(22222L);
+
+    QueryWrapper<AlarmRule> queryWrapper = new QueryWrapper<>();
+    queryWrapper.in("id", Collections.singletonList("22222"));
+    queryWrapper.and(
+        wrapper -> wrapper.eq("creator", mu.getLoginName()).or().eq("modifier", mu.getLoginName()));
+
+    Mockito.when(facade.alarmGroupService.getListByUserLike("test_userId", "test_tenant"))
+        .thenReturn(Collections.singletonList(alarmGroupDTO));
+    Mockito.when(facade.alarmSubscribeService.queryByMap(Mockito.anyMap()))
+        .thenReturn(Collections.singletonList(alarmSubscribeInfo));
+    Mockito.when(facade.alarmRuleService.list(Mockito.any()))
+        .thenReturn(Collections.singletonList(alarmRule));
+  }
+
+  @Captor
+  ArgumentCaptor<QueryWrapper<AlarmRule>> argument;
+
+  @Test
+  public void testGetRuleListByGroup() {
+    List<AlarmRuleDTO> alarmRuleDTOList = facade.getRuleListByGroup(true);
+
+    Mockito.verify(facade.alarmRuleService).list(argument.capture());
+    QueryWrapper<AlarmRule> queryWrapper = argument.getValue();
+    Assert.assertEquals(
+        "(id IN (#{ew.paramNameValuePairs.MPGENVAL1}) AND (creator = #{ew.paramNameValuePairs.MPGENVAL2} OR modifier = #{ew.paramNameValuePairs.MPGENVAL3}))",
+        queryWrapper.getExpression().getSqlSegment());
+
+    Assert.assertFalse(CollectionUtils.isEmpty(alarmRuleDTOList));
+
+    AlarmRuleDTO alarmRuleDTO = alarmRuleDTOList.get(0);
+    Assert.assertEquals(alarmRuleDTO.getId().longValue(), 22222L);
+  }
+
+  @Test
+  public void testGetRuleListByGroup_false() {
+    facade.getRuleListByGroup(false);
+    Mockito.verify(facade.alarmRuleService).list(argument.capture());
+    QueryWrapper<AlarmRule> queryWrapper = argument.getValue();
+    Assert.assertEquals("(id IN (#{ew.paramNameValuePairs.MPGENVAL1}))",
+        queryWrapper.getExpression().getSqlSegment());
+  }
+
+  @Test
+  public void testGetRuleListBySubscribe() {
+    List<AlarmRuleDTO> alarmRuleDTOList = facade.getRuleListBySubscribe(true);
+    Mockito.verify(facade.alarmRuleService).list(argument.capture());
+    QueryWrapper<AlarmRule> queryWrapper = argument.getValue();
+    Assert.assertEquals(
+        "(id IN (#{ew.paramNameValuePairs.MPGENVAL1}) AND (creator = #{ew.paramNameValuePairs.MPGENVAL2} OR modifier = #{ew.paramNameValuePairs.MPGENVAL3}))",
+        queryWrapper.getExpression().getSqlSegment());
+
+    Assert.assertFalse(CollectionUtils.isEmpty(alarmRuleDTOList));
+
+    AlarmRuleDTO alarmRuleDTO = alarmRuleDTOList.get(0);
+    Assert.assertEquals(alarmRuleDTO.getId().longValue(), 22222L);
+  }
+
+  @Test
+  public void testGetRuleListBySubscribe_false() {
+    List<AlarmRuleDTO> alarmRuleDTOList = facade.getRuleListBySubscribe(false);
+    Mockito.verify(facade.alarmRuleService).list(argument.capture());
+    QueryWrapper<AlarmRule> queryWrapper = argument.getValue();
+    Assert.assertEquals("(id IN (#{ew.paramNameValuePairs.MPGENVAL1}))",
+        queryWrapper.getExpression().getSqlSegment());
+  }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #234 


# What changes are included in this PR?

Using login name as filtering condition when users query alert rule in "I create" condition.

# Are there any user-facing changes?

In the personal center users can use "I create" to filter alert rules.

# How does this change test

`server/home/home-facade/src/test/java/io/holoinsight/server/home/facade/AlarmRuleDTOTest.java`
`server/home/home-web/src/test/java/io/holoinsight/server/home/web/controller/AlarmRuleFacadeImplTest.java`
