### PR TITLE
fix: Resolve problem that blackfilters in logmonitor take not effect

### DIFF
--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
@@ -147,7 +147,7 @@ public class GaeaSqlTaskUtil {
 
       }
 
-      parse.setWhere(buildFrontFilterWhere(whiteFilters, blackFilters, logParse.splitType));
+      parse.setWhere(buildFrontFilterWhere(whiteFilters, blackFilters));
 
       List<Log.LogPath> pathList = new ArrayList<>();
       logPaths.forEach(logPath -> {
@@ -219,8 +219,7 @@ public class GaeaSqlTaskUtil {
   }
 
   // 前置过滤
-  public static Where buildFrontFilterWhere(List<Filter> whiteFilters, List<Filter> blackFilters,
-      String splitType) {
+  public static Where buildFrontFilterWhere(List<Filter> whiteFilters, List<Filter> blackFilters) {
 
 
     Where where = new Where();
@@ -268,7 +267,7 @@ public class GaeaSqlTaskUtil {
         Where not = new Where();
 
         Elect elect = new Elect();
-        switch (splitType) {
+        switch (w.getType()) {
           case leftRight:
             Elect.LeftRight leftRight = new Elect.LeftRight();
             leftRight.setLeft(w.rule.left);


### PR DESCRIPTION

# Which issue does this PR close?

Closes #236 

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Now the segmentation rule for blacklist filtering uses the log partitioning rule,  as a result, the configuration does not take effect.




# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
