### PR TITLE
feat(home): add fuse protector

### DIFF
--- a/server/common/common-service/src/main/java/io/holoinsight/server/common/service/FuseProtector.java
+++ b/server/common/common-service/src/main/java/io/holoinsight/server/common/service/FuseProtector.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.common.service;
+
+import org.springframework.util.CollectionUtils;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Monitor background tasks such as alarm calculation, and fuse when the threshold is reached. Used
+ * for health check, e2e test.
+ *
+ * @author masaimu
+ * @version 2023-03-13 18:27:00
+ */
+public class FuseProtector {
+
+  private static final String CRITICAL = "critical";
+  private static final String NORMAL = "normal";
+
+  public static final String CRITICAL_AlertSaveHistoryHandler = "AlertSaveHistoryHandler";
+  public static final String CRITICAL_AlertTaskCompute = "AlertTaskCompute";
+  public static final String CRITICAL_AlertTaskScheduler = "AlertTaskScheduler";
+  public static final String CRITICAL_GetSubscription = "GetSubscription";
+
+  public static final String NORMAL_NotifyChain = "NotifyChain";
+  public static final String NORMAL_AlertNotifyHandler = "AlertNotifyHandler";
+  public static final String NORMAL_AlertSaveHistoryDetail = "AlertSaveHistoryDetail";
+  public static final String NORMAL_MakeAlertRecover = "MakeAlertRecover";
+  public static final String NORMAL_GetSubscriptionDetail = "GetSubscriptionDetail";
+
+  protected static Map<String /* name */, List<EventResult>> criticalEventMap =
+      new ConcurrentHashMap<>();
+  protected static Map<String /* name */, List<EventResult>> normalEventMap =
+      new ConcurrentHashMap<>();
+  protected static Map<String /* name */, AtomicInteger> completeEventMap =
+      new ConcurrentHashMap<>();
+
+  public static void voteCriticalError(String name, String msg) {
+    List<EventResult> set =
+        criticalEventMap.computeIfAbsent(name, k -> new CopyOnWriteArrayList<>());
+    set.add(new EventResult(CRITICAL, name, msg));
+  }
+
+  public static void voteNormalError(String name, String msg) {
+    List<EventResult> set = normalEventMap.computeIfAbsent(name, k -> new CopyOnWriteArrayList<>());
+    set.add(new EventResult(NORMAL, name, msg));
+  }
+
+  public static void voteComplete(String name) {
+    AtomicInteger atomicInteger = completeEventMap.computeIfAbsent(name, k -> new AtomicInteger(0));
+    atomicInteger.incrementAndGet();
+  }
+
+  /**
+   *
+   * @throws HoloInsightCriticalException failed assert
+   */
+  public static synchronized void doAssert() throws HoloInsightCriticalException {
+    if (!CollectionUtils.isEmpty(criticalEventMap)) {
+      EventResult eventResult = getFirstEventResult(criticalEventMap, 0);
+      if (eventResult != null) {
+        throw new HoloInsightCriticalException(eventResult.msg, eventResult.name,
+            eventResult.timestamp);
+      }
+    }
+
+    if (CollectionUtils.isEmpty(normalEventMap)) {
+      return;
+    }
+
+    if (CollectionUtils.isEmpty(completeEventMap)) {
+      EventResult eventResult = getFirstEventResult(normalEventMap, 10);
+      if (eventResult != null) {
+        throw new HoloInsightCriticalException(eventResult.msg, eventResult.name,
+            eventResult.timestamp);
+      }
+    }
+
+    compareSize(completeEventMap, normalEventMap, 10);
+  }
+
+  /**
+   *
+   * @return true: pass, false: pending
+   */
+  public static synchronized boolean doAssert(List<String> keywords) {
+    if (!CollectionUtils.isEmpty(keywords)) {
+      for (String keyword : keywords) {
+        AtomicInteger atomicInteger = completeEventMap.get(keyword);
+        if (atomicInteger == null || atomicInteger.get() <= 0) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  public static synchronized void clean() {
+    criticalEventMap = new ConcurrentHashMap<>();
+    normalEventMap = new ConcurrentHashMap<>();
+    completeEventMap = new ConcurrentHashMap<>();
+  }
+
+  private static void compareSize(Map<String, AtomicInteger> completeEventMap,
+      Map<String, List<EventResult>> normalEventMap, int threshold) {
+    Set<String> keySet = new HashSet<>();
+    keySet.addAll(completeEventMap.keySet());
+    keySet.addAll(normalEventMap.keySet());
+    for (String key : keySet) {
+      AtomicInteger completeList = completeEventMap.get(key);
+      int completeSize = completeList == null ? 0 : completeList.get();
+      List<EventResult> normalList = normalEventMap.get(key);
+      int normalSize = CollectionUtils.isEmpty(normalList) ? 0 : normalList.size();
+      if (completeSize < normalSize && normalSize > threshold) {
+        throw new HoloInsightCriticalException("more fail result", key);
+      }
+    }
+  }
+
+  private static EventResult getFirstEventResult(Map<String, List<EventResult>> eventMap,
+      int threshold) {
+    for (Map.Entry<String /* name */, List<EventResult>> entry : eventMap.entrySet()) {
+      List<EventResult> eventResults = entry.getValue();
+      if (!CollectionUtils.isEmpty(eventResults) && eventResults.size() > threshold) {
+        return eventResults.get(0);
+      }
+    }
+    return null;
+  }
+
+  public static class EventResult {
+    String level;
+    String name;
+    String msg;
+    long timestamp;
+
+    public EventResult(String level, String name, String msg) {
+      this.level = level;
+      this.name = name;
+      this.msg = msg;
+      this.timestamp = System.currentTimeMillis();
+    }
+  }
+}

--- a/server/common/common-service/src/main/java/io/holoinsight/server/common/service/HoloInsightCriticalException.java
+++ b/server/common/common-service/src/main/java/io/holoinsight/server/common/service/HoloInsightCriticalException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.common.service;
+
+/**
+ * @author masaimu
+ * @version 2023-03-13 21:06:00
+ */
+public class HoloInsightCriticalException extends RuntimeException {
+
+  public String name;
+  public long timestamp;
+
+  public HoloInsightCriticalException(String message, String name, long timestamp) {
+    super(message);
+    this.name = name;
+    this.timestamp = timestamp;
+  }
+
+  public HoloInsightCriticalException(String message, String name) {
+    super(message);
+    this.name = name;
+    this.timestamp = System.currentTimeMillis();
+  }
+}

--- a/server/common/common-service/src/test/java/io/holoinsight/server/common/service/FuseProtectorTest.java
+++ b/server/common/common-service/src/test/java/io/holoinsight/server/common/service/FuseProtectorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package io.holoinsight.server.common.service;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Arrays;
+
+import static io.holoinsight.server.common.service.FuseProtector.CRITICAL_AlertSaveHistoryHandler;
+import static io.holoinsight.server.common.service.FuseProtector.CRITICAL_AlertTaskCompute;
+import static io.holoinsight.server.common.service.FuseProtector.CRITICAL_AlertTaskScheduler;
+import static io.holoinsight.server.common.service.FuseProtector.NORMAL_NotifyChain;
+
+/**
+ * @author masaimu
+ * @version 2023-03-15 15:54:00
+ */
+public class FuseProtectorTest {
+
+  @After
+  public void tearDown() throws Exception {
+    FuseProtector.clean();
+  }
+
+  @Test
+  public void testVoteCriticalError() {
+    FuseProtector.voteCriticalError(CRITICAL_AlertSaveHistoryHandler, "test critical");
+    Exception exception = null;
+    try {
+      FuseProtector.doAssert();
+    } catch (Exception e) {
+      exception = e;
+    }
+    Assert.notNull(exception, "can not be null");
+    Assert.isInstanceOf(HoloInsightCriticalException.class, exception);
+    Assert.isTrue(StringUtils.equals("test critical", exception.getMessage()), "exception equal");
+  }
+
+  @Test
+  public void testVoteNormalError() {
+    FuseProtector.voteNormalError(NORMAL_NotifyChain, "test normal");
+    Exception exception = null;
+    try {
+      FuseProtector.doAssert();
+    } catch (Exception e) {
+      exception = e;
+    }
+    Assert.isNull(exception, "should be null");
+
+    for (int i = 0; i < 10; i++) {
+      FuseProtector.voteNormalError(NORMAL_NotifyChain, "test normal");
+    }
+    try {
+      FuseProtector.doAssert();
+    } catch (Exception e) {
+      exception = e;
+    }
+    Assert.notNull(exception, "can not be null");
+    Assert.isInstanceOf(HoloInsightCriticalException.class, exception);
+    Assert.isTrue(StringUtils.equals("test normal", exception.getMessage()), "exception equal");
+  }
+
+  @Test
+  public void testVoteComplete() {
+    Assert.isTrue(
+        !FuseProtector
+            .doAssert(Arrays.asList(CRITICAL_AlertTaskCompute, CRITICAL_AlertTaskScheduler)),
+        "should be pending");
+
+    FuseProtector.voteComplete(CRITICAL_AlertTaskCompute);
+    Assert.isTrue(
+        !FuseProtector
+            .doAssert(Arrays.asList(CRITICAL_AlertTaskCompute, CRITICAL_AlertTaskScheduler)),
+        "should be pending");
+
+    FuseProtector.voteComplete(CRITICAL_AlertTaskScheduler);
+    Assert.isTrue(
+        FuseProtector
+            .doAssert(Arrays.asList(CRITICAL_AlertTaskCompute, CRITICAL_AlertTaskScheduler)),
+        "should complete");
+  }
+
+  @Test
+  public void testClean() {
+    FuseProtector.voteNormalError(NORMAL_NotifyChain, "test normal");
+    FuseProtector.voteComplete(CRITICAL_AlertTaskCompute);
+    FuseProtector.voteCriticalError(CRITICAL_AlertSaveHistoryHandler, "test critical");
+    FuseProtector.clean();
+    Assert.isTrue(CollectionUtils.isEmpty(FuseProtector.criticalEventMap), "should be cleaned");
+    Assert.isTrue(CollectionUtils.isEmpty(FuseProtector.normalEventMap), "should be cleaned");
+    Assert.isTrue(CollectionUtils.isEmpty(FuseProtector.completeEventMap), "should be cleaned");
+
+  }
+}

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/NotifyChain.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/NotifyChain.java
@@ -3,6 +3,7 @@
  */
 package io.holoinsight.server.home.alert.plugin;
 
+import io.holoinsight.server.common.service.FuseProtector;
 import io.holoinsight.server.home.biz.plugin.model.ChainPlugin;
 import io.holoinsight.server.home.biz.plugin.model.PluginContext;
 import io.holoinsight.server.home.biz.plugin.model.PluginModel;
@@ -16,6 +17,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
+
+import static io.holoinsight.server.common.service.FuseProtector.NORMAL_NotifyChain;
 
 /**
  * 通知流程
@@ -101,6 +104,7 @@ public class NotifyChain extends ChainPlugin implements Runnable {
   public void run() {
     try {
       handle();
+      FuseProtector.voteComplete(NORMAL_NotifyChain);
     } catch (HoloinsightAlertIllegalArgumentException e) {
       LOGGER.error(
           "[HoloinsightAlertIllegalArgumentException][1] {} fail to handle notify chain for {}",
@@ -108,6 +112,7 @@ public class NotifyChain extends ChainPlugin implements Runnable {
     } catch (Throwable e) {
       LOGGER.error("[HoloinsightAlertInternalException][1] {} fail to handle notify chain for {}",
           this.traceId, e.getMessage(), e);
+      FuseProtector.voteNormalError(NORMAL_NotifyChain, e.getMessage());
     }
   }
 

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskCompute.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskCompute.java
@@ -4,6 +4,7 @@
 package io.holoinsight.server.home.alert.service.calculate;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import io.holoinsight.server.common.service.FuseProtector;
 import io.holoinsight.server.home.alert.common.AlertStat;
 import io.holoinsight.server.home.alert.common.G;
 import io.holoinsight.server.home.alert.model.compute.ComputeContext;
@@ -35,6 +36,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static io.holoinsight.server.common.service.FuseProtector.CRITICAL_AlertTaskCompute;
 
 /**
  * @author wangsiyuan
@@ -89,7 +92,9 @@ public class AlertTaskCompute implements AlarmTaskExecutor<ComputeTaskPackage> {
       LOGGER.error(
           "[HoloinsightAlertInternalException][AlertTaskCompute][{}] fail to execute alert task compute for {}",
           computeTaskPackage.inspectConfigs.size(), e.getMessage(), e);
+      FuseProtector.voteCriticalError(CRITICAL_AlertTaskCompute, e.getMessage());
     } finally {
+      FuseProtector.voteComplete(CRITICAL_AlertTaskCompute);
       Map<String, Map<String, Long>> counterMap = AlertStat.statRuleTypeCount(computeTaskPackage);
       for (Map.Entry<String /* tenant */, Map<String /* ruleType */, Long>> entry : counterMap
           .entrySet()) {

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/task/AlertTaskScheduler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/task/AlertTaskScheduler.java
@@ -3,6 +3,7 @@
  */
 package io.holoinsight.server.home.alert.service.task;
 
+import io.holoinsight.server.common.service.FuseProtector;
 import io.holoinsight.server.home.alert.model.compute.ComputeTaskPackage;
 import io.holoinsight.server.home.alert.service.calculate.AlertTaskCompute;
 import io.holoinsight.server.home.common.exception.HoloinsightAlertInternalException;
@@ -21,6 +22,7 @@ import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -31,6 +33,9 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static io.holoinsight.server.common.service.FuseProtector.CRITICAL_AlertTaskCompute;
+import static io.holoinsight.server.common.service.FuseProtector.CRITICAL_AlertTaskScheduler;
 
 /**
  * @author wangsiyuan
@@ -69,7 +74,10 @@ public class AlertTaskScheduler {
       logger.error(
           "[HoloinsightAlertInternalException][AlertTaskScheduler] fail to schedule alert task for {}",
           e.getMessage());
+      FuseProtector.voteCriticalError(CRITICAL_AlertTaskScheduler, e.getMessage());
       throw new HoloinsightAlertInternalException(e);
+    } finally {
+      FuseProtector.voteComplete(CRITICAL_AlertTaskScheduler);
     }
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #240 

# Rationale for this change
 
`FuseProtector` records the state at each step in the alert detection process, it provide assertions to help the caller to check whether the alert detection task completed successfully.

# What changes are included in this PR?

- Add `FuseProtector`
- Recording alert detection stat using `FuseProtector`

# Are there any user-facing changes?

None.

# How does this change test

Unit test: `server/common/common-service/src/test/java/io/holoinsight/server/common/service/FuseProtectorTest.java`
