### PR TITLE
feat: implement APM-related query interfaces in DefaultQueryServiceImpl.java

### DIFF
--- a/server/query/query-service/src/main/java/io/holoinsight/server/query/service/apm/ApmAPI.java
+++ b/server/query/query-service/src/main/java/io/holoinsight/server/query/service/apm/ApmAPI.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.query.service.apm;
+
+import io.holoinsight.server.apm.common.model.query.BizopsEndpoint;
+import io.holoinsight.server.apm.common.model.query.Endpoint;
+import io.holoinsight.server.apm.common.model.query.MetricValues;
+import io.holoinsight.server.apm.common.model.query.QueryComponentRequest;
+import io.holoinsight.server.apm.common.model.query.QueryEndpointRequest;
+import io.holoinsight.server.apm.common.model.query.QueryMetricRequest;
+import io.holoinsight.server.apm.common.model.query.QueryServiceInstanceRequest;
+import io.holoinsight.server.apm.common.model.query.QueryServiceRequest;
+import io.holoinsight.server.apm.common.model.query.QueryTopologyRequest;
+import io.holoinsight.server.apm.common.model.query.QueryTraceRequest;
+import io.holoinsight.server.apm.common.model.query.Service;
+import io.holoinsight.server.apm.common.model.query.ServiceInstance;
+import io.holoinsight.server.apm.common.model.query.SlowSql;
+import io.holoinsight.server.apm.common.model.query.Topology;
+import io.holoinsight.server.apm.common.model.query.TraceBrief;
+import io.holoinsight.server.apm.common.model.query.VirtualComponent;
+import io.holoinsight.server.apm.common.model.specification.sw.Trace;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
+
+import java.util.List;
+
+public interface ApmAPI {
+
+  @POST("/cluster/api/v1/trace/query/basic")
+  Call<TraceBrief> queryBasicTraces(@Body QueryTraceRequest request);
+
+  @POST("/cluster/api/v1/trace/query")
+  Call<Trace> queryTrace(@Body QueryTraceRequest request);
+
+  @POST("/cluster/api/v1/metric/list")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Call<List<String>> listMetrics();
+
+  @POST("/cluster/api/v1/metric/schema")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Call<List<String>> querySchema(@Body QueryMetricRequest request);
+
+  @POST("/cluster/api/v1/metric/query")
+  Call<MetricValues> queryMetricData(@Body QueryMetricRequest request);
+
+  @POST("/cluster/api/v1/service/query/serviceList")
+  Call<List<Service>> queryServiceList(@Body QueryServiceRequest request);
+
+  @POST("/cluster/api/v1/endpoint/query/endpointList")
+  Call<List<Endpoint>> queryEndpointList(@Body QueryEndpointRequest request);
+
+  @POST("/cluster/api/v1/serviceInstance/query/serviceInstanceList")
+  Call<List<ServiceInstance>> queryServiceInstanceList(@Body QueryServiceInstanceRequest request);
+
+  @POST("/cluster/api/v1/component/query/dbList")
+  Call<List<VirtualComponent>> queryDbList(@Body QueryComponentRequest request);
+
+  @POST("/cluster/api/v1/component/query/cacheList")
+  Call<List<VirtualComponent>> queryCacheList(@Body QueryComponentRequest request);
+
+  @POST("/cluster/api/v1/component/query/mqList")
+  Call<List<VirtualComponent>> queryMQList(@Body QueryComponentRequest request);
+
+  @POST("/cluster/api/v1/component/query/componentTraceIds")
+  Call<List<String>> queryComponentTraceIds(@Body QueryComponentRequest request);
+
+  @POST("/cluster/api/v1/topology/query/tenantTopology")
+  Call<Topology> queryTenantTopology(@Body QueryTopologyRequest request);
+
+  @POST("/cluster/api/v1/topology/query/serviceTopology")
+  Call<Topology> queryServiceTopology(@Body QueryTopologyRequest request);
+
+  @POST("/cluster/api/v1/topology/query/serviceInstanceTopology")
+  Call<Topology> queryServiceInstanceTopology(@Body QueryTopologyRequest request);
+
+  @POST("/cluster/api/v1/topology/query/endpointTopology")
+  Call<Topology> queryEndpointTopology(@Body QueryTopologyRequest request);
+
+  @POST("/cluster/api/v1/topology/query/dbTopology")
+  Call<Topology> queryDbTopology(@Body QueryTopologyRequest request);
+
+  @POST("/cluster/api/v1/topology/query/mqTopology")
+  Call<Topology> queryMQTopology(@Body QueryTopologyRequest request);
+
+  @POST("/cluster/api/v1/endpoint/bizops/endpointList")
+  Call<List<BizopsEndpoint>> queryBizEndpointList(@Body QueryEndpointRequest request);
+
+  @POST("/cluster/api/v1/endpoint/bizops/errorCodeList")
+  Call<List<BizopsEndpoint>> queryBizErrorCodeList(@Body QueryEndpointRequest request);
+
+  @POST("/cluster/api/v1/slowSql/query")
+  Call<List<SlowSql>> querySlowSqlList(@Body QueryComponentRequest request);
+}

--- a/server/query/query-service/src/main/java/io/holoinsight/server/query/service/apm/ApmClient.java
+++ b/server/query/query-service/src/main/java/io/holoinsight/server/query/service/apm/ApmClient.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.query.service.apm;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.holoinsight.server.common.dao.mapper.TenantOpsMapper;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+import javax.annotation.Resource;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author xiangwanpeng
+ * @version : StorageClient.java, v 0.1 2022年10月03日 17:39 xiangwanpeng Exp $
+ */
+@Configuration
+@ConfigurationProperties(prefix = "holoinsight.query.apm")
+@Component
+@Slf4j
+@Data
+public class ApmClient {
+
+  private String address;
+
+  @Resource
+  private TenantOpsMapper tenantOpsMapper;
+
+  private LoadingCache<String, ApmAPI> clients = CacheBuilder.newBuilder()
+      .expireAfterWrite(60, TimeUnit.SECONDS).build(new CacheLoader<String, ApmAPI>() {
+        @Override
+        public ApmAPI load(String tenantName) throws Exception {
+          return createApmAPI(tenantName);
+        }
+      });
+
+  public ApmAPI getClient(String tenant) {
+    try {
+      return clients.get(tenant);
+    } catch (Exception e) {
+      log.error("apm client create fail: {}, msg={}", tenant, e.getMessage());
+      return null;
+    }
+  }
+
+  private ApmAPI createApmAPI(String tenant) {
+    if (StringUtils.isBlank(tenant)) {
+      tenant = "dev";
+    }
+    Assert.notNull(address, "apm config not found for tenant: " + tenant);
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    OkHttpClient okHttpClient = new OkHttpClient.Builder().readTimeout(60 * 3, TimeUnit.SECONDS)
+        .connectTimeout(60 * 3, TimeUnit.SECONDS).build();
+
+    Retrofit retrofit = new Retrofit.Builder().baseUrl(address)
+        .addConverterFactory(JacksonConverterFactory.create(objectMapper)).client(okHttpClient)
+        .build();
+
+    return retrofit.create(ApmAPI.class);
+  }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #239 

# Rationale for this change
Complete the actual implementation of the APM-related query interface in DefaultQueryServiceImpl.java instead of returning an empty instance as before.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
DefaultQueryServiceImpl.java has been modified.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Almost none, note that it is only the implementation of some interfaces, which does not mean that the APM module is fully available.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Regression tests passed in my local test environment.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
