### PR TITLE
feat(home): scheduling alert detection separately according to ruleType

### DIFF
--- a/server/home/home-alert/pom.xml
+++ b/server/home/home-alert/pom.xml
@@ -91,5 +91,11 @@
             <artifactId>common-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/task/CacheAlertTaskTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/task/CacheAlertTaskTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package io.holoinsight.server.home.alert.service.task;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import io.holoinsight.server.home.dal.mapper.AlarmRuleMapper;
+import io.holoinsight.server.home.dal.model.AlarmRule;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+/**
+ * @author masaimu
+ * @version 2023-03-16 11:29:00
+ */
+public class CacheAlertTaskTest {
+
+  @Test
+  public void testSetMethod() {
+    CacheAlertTask cacheAlertTask = new CacheAlertTask();
+
+    cacheAlertTask.setAiPageNum(10);
+    Assert.assertEquals(cacheAlertTask.aiPageNum.get(), 10);
+    cacheAlertTask.setAiPageSize(11);
+    Assert.assertEquals(cacheAlertTask.aiPageSize.get(), 11);
+
+    cacheAlertTask.setRulePageNum(12);
+    Assert.assertEquals(cacheAlertTask.rulePageNum.get(), 12);
+    cacheAlertTask.setRulePageSize(13);
+    Assert.assertEquals(cacheAlertTask.rulePageSize.get(), 13);
+
+    cacheAlertTask.setPqlPageNum(14);
+    Assert.assertEquals(cacheAlertTask.pqlPageNum.get(), 14);
+    cacheAlertTask.setPqlPageSize(15);
+    Assert.assertEquals(cacheAlertTask.pqlPageSize.get(), 15);
+  }
+
+  @Captor
+  ArgumentCaptor<QueryWrapper<AlarmRule>> ruleArgument;
+
+  @Test
+  public void testGetAlarmRuleListByPage() {
+    MockitoAnnotations.openMocks(this);
+    CacheAlertTask cacheAlertTask = new CacheAlertTask();
+
+    cacheAlertTask.setAiPageNum(10);
+    cacheAlertTask.setAiPageSize(11);
+
+    cacheAlertTask.setRulePageNum(12);
+    cacheAlertTask.setRulePageSize(13);
+
+    cacheAlertTask.setPqlPageNum(14);
+    cacheAlertTask.setPqlPageSize(15);
+
+    cacheAlertTask.alarmRuleDOMapper = Mockito.mock(AlarmRuleMapper.class);
+    cacheAlertTask.getAlarmRuleListByPage();
+    Mockito.verify(cacheAlertTask.alarmRuleDOMapper, Mockito.times(3))
+        .selectList(ruleArgument.capture());
+
+    List<QueryWrapper<AlarmRule>> list = ruleArgument.getAllValues();
+
+    QueryWrapper<AlarmRule> rule = list.get(0);
+    QueryWrapper<AlarmRule> ai = list.get(1);
+    QueryWrapper<AlarmRule> pql = list.get(2);
+
+    Assert.assertEquals("rule",
+        "WHERE (rule_type = #{ew.paramNameValuePairs.MPGENVAL1}) ORDER BY id DESC limit 13 offset 12",
+        rule.getCustomSqlSegment());
+    Assert.assertEquals("ai",
+        "WHERE (rule_type = #{ew.paramNameValuePairs.MPGENVAL1}) ORDER BY id DESC limit 11 offset 10",
+        ai.getCustomSqlSegment());
+    Assert.assertEquals("pql",
+        "WHERE (rule_type = #{ew.paramNameValuePairs.MPGENVAL1}) ORDER BY id DESC limit 15 offset 14",
+        pql.getCustomSqlSegment());
+  }
+}

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/task/coordinator/CoordinatorServiceTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/task/coordinator/CoordinatorServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package io.holoinsight.server.home.alert.service.task.coordinator;
+
+import io.holoinsight.server.home.alert.service.task.CacheAlertTask;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author masaimu
+ * @version 2023-03-16 10:33:00
+ */
+public class CoordinatorServiceTest {
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Captor
+  ArgumentCaptor<Integer> rulePageSizeArgument;
+  @Captor
+  ArgumentCaptor<Integer> rulePageNumArgument;
+  @Captor
+  ArgumentCaptor<Integer> aiPageSizeArgument;
+  @Captor
+  ArgumentCaptor<Integer> aiPageNumArgument;
+  @Captor
+  ArgumentCaptor<Integer> pqlPageSizeArgument;
+  @Captor
+  ArgumentCaptor<Integer> pqlPageNumArgument;
+
+  @Test
+  public void testCalculateSelectRange() {
+    CoordinatorService service = new CoordinatorService();
+    service.orderMap = Mockito.mock(OrderMap.class);
+    Mockito.when(service.orderMap.getRealSize()).thenReturn(3);
+    service.cacheAlertTask = Mockito.mock(CacheAlertTask.class);
+    Mockito.when(service.cacheAlertTask.ruleSize("ai")).thenReturn(73);
+    Mockito.when(service.cacheAlertTask.ruleSize("rule")).thenReturn(43);
+    Mockito.when(service.cacheAlertTask.ruleSize("pql")).thenReturn(1);
+
+    order(service);
+  }
+
+  private void order(CoordinatorService service) {
+    service.calculateSelectRange(0);
+    service.calculateSelectRange(1);
+    service.calculateSelectRange(2);
+    Mockito.verify(service.cacheAlertTask, Mockito.times(3))
+        .setRulePageNum(rulePageNumArgument.capture());
+    List<Integer> rulePageNums = rulePageNumArgument.getAllValues();
+    Assert.assertEquals(rulePageNums, Arrays.asList(0, 15, 30));
+
+    Mockito.verify(service.cacheAlertTask, Mockito.times(3))
+        .setRulePageSize(rulePageSizeArgument.capture());
+    List<Integer> rulePageSize = rulePageSizeArgument.getAllValues();
+    Assert.assertEquals(rulePageSize, Arrays.asList(15, 15, 15));
+
+    Mockito.verify(service.cacheAlertTask, Mockito.times(3))
+        .setAiPageNum(aiPageNumArgument.capture());
+    List<Integer> aiPageNum = aiPageNumArgument.getAllValues();
+    Assert.assertEquals(aiPageNum, Arrays.asList(0, 25, 50));
+
+    Mockito.verify(service.cacheAlertTask, Mockito.times(3))
+        .setAiPageSize(aiPageSizeArgument.capture());
+    List<Integer> aiPageSize = aiPageSizeArgument.getAllValues();
+    Assert.assertEquals(aiPageSize, Arrays.asList(25, 25, 25));
+
+    Mockito.verify(service.cacheAlertTask, Mockito.times(3))
+        .setPqlPageNum(pqlPageNumArgument.capture());
+    List<Integer> pqlPageNum = pqlPageNumArgument.getAllValues();
+    Assert.assertEquals(pqlPageNum, Arrays.asList(0, 1, 2));
+
+    Mockito.verify(service.cacheAlertTask, Mockito.times(3))
+        .setPqlPageSize(pqlPageSizeArgument.capture());
+    List<Integer> pqlPageSize = pqlPageSizeArgument.getAllValues();
+    Assert.assertEquals(pqlPageSize, Arrays.asList(1, 1, 1));
+  }
+}

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlarmRuleDTO.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlarmRuleDTO.java
@@ -39,7 +39,7 @@ public class AlarmRuleDTO {
   private String ruleName;
 
   /**
-   * 规则类型（AI、RULE）
+   * 规则类型（ai、rule、pql）
    */
   private String ruleType;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #244 

# What changes are included in this PR?

- Invoke `io.holoinsight.server.home.alert.service.task.CacheAlertTask#getAlertRule` separately according to ruleType.
- Calculate `pageSize` and `pageNum` separately according to ruleType.

# Are there any user-facing changes?

None.

# How does this change test

Unit tests:
- `server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/task/CacheAlertTaskTest.java`
- `server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/task/coordinator/CoordinatorServiceTest.java`
