### PR TITLE
fix: deleting the gaea collectconfig when deleting the logmonitor config

### DIFF
--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/CustomPluginServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/CustomPluginServiceImpl.java
@@ -79,13 +79,13 @@ public class CustomPluginServiceImpl extends ServiceImpl<CustomPluginMapper, Cus
 
   @Override
   public void deleteById(Long id) {
-    CustomPlugin customPluginDTO = getById(id);
-    if (null == customPluginDTO) {
+    CustomPlugin customPlugin = getById(id);
+    if (null == customPlugin) {
       return;
     }
     removeById(id);
-    customPluginDTO.setStatus("OFFLINE");
-    EventBusHolder.post(customPluginDTO);
+    customPlugin.setStatus("OFFLINE");
+    EventBusHolder.post(doToDTO(customPlugin));
   }
 
   @Override


### PR DESCRIPTION

# Which issue does this PR close?

Closes #

# Rationale for this change
 



# What changes are included in this PR?

1. solve problem of deleting the collection configuration when deleting the log monitoring configuration

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
