### PR TITLE
feat: optimize integration with elasticsearch

### DIFF
--- a/server/apm/apm-server/apm-core/src/main/java/io/holoinsight/server/apm/core/installer/ModelInstallManager.java
+++ b/server/apm/apm-server/apm-core/src/main/java/io/holoinsight/server/apm/core/installer/ModelInstallManager.java
@@ -12,6 +12,7 @@ import io.holoinsight.server.apm.core.ModelCenter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -47,7 +48,7 @@ public class ModelInstallManager {
   private List<Model> scanModels() throws IOException {
     List<Model> models = new ArrayList<>();
     Collection<Class<?>> modelPathClasses = ClassUtil.getClasses(MODEL_PATH);
-    log.info("[storage] load {} models, path={}",
+    log.info("[apm] load {} models, path={}",
         modelPathClasses == null ? 0 : modelPathClasses.size(), MODEL_PATH);
     for (Class<?> cls : modelPathClasses) {
       if (cls.isAnnotationPresent(ModelAnnotation.class)) {
@@ -72,8 +73,10 @@ public class ModelInstallManager {
   private void installModel(Model model) {
     for (ModelInstaller installer : installers) {
       installer.install(model);
-      modelManager.register(model);
+      log.info("[apm] model installed, model={}, installer={}", model.getName(),
+          installer.getClass().getSimpleName());
     }
+    modelManager.register(model);
   }
 
 }

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/HoloinsightEsConfiguration.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/HoloinsightEsConfiguration.java
@@ -49,7 +49,8 @@ public class HoloinsightEsConfiguration {
   private String user;
   private String password;
 
-  @Bean
+  @Bean("elasticsearchClient")
+  @Primary
   public RestHighLevelClient elasticsearchClient() {
     log.info("init es config, hosts={}, port={}", hosts, port);
     List<HttpHost> httpHosts =

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/installer/EsModelInstaller.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/installer/EsModelInstaller.java
@@ -150,10 +150,10 @@ public class EsModelInstaller implements ModelInstaller {
   }
 
   protected Settings createSettings(Model model) {
-    Settings settings =
-        Settings.builder().put("index.number_of_replicas", 1).put("index.number_of_shards", 5)
-            .put("index.refresh_interval", "10s").put("number_of_replicas", 1)
-            .put("number_of_shards", 5).put("refresh_interval", "10s").build();
+    // for different versions of elasticsearch
+    Settings settings = Settings.builder().put("index.number_of_replicas", 1)
+        .put("number_of_replicas", 1).put("index.number_of_shards", 5).put("number_of_shards", 5)
+        .put("index.refresh_interval", "10s").put("refresh_interval", "10s").build();
     return settings;
   }
 

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanEsStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanEsStorage.java
@@ -50,9 +50,6 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
 
   private static final int SPAN_QUERY_MAX_SIZE = 2000;
 
-  @Autowired
-  private RestHighLevelClient esClient;
-
   @Override
   public TraceBrief queryBasicTraces(final String tenant, String serviceName,
       String serviceInstanceName, String endpointName, List<String> traceIds, int minTraceDuration,
@@ -127,7 +124,7 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
     SearchRequest searchRequest =
         new SearchRequest(new String[] {SpanDO.INDEX_NAME}, searchSourceBuilder);
 
-    SearchResponse searchResponse = esClient.search(searchRequest, RequestOptions.DEFAULT);
+    SearchResponse searchResponse = esClient().search(searchRequest, RequestOptions.DEFAULT);
     final TraceBrief traceBrief = new TraceBrief();
     for (org.elasticsearch.search.SearchHit hit : searchResponse.getHits().getHits()) {
       String hitJson = hit.getSourceAsString();
@@ -145,7 +142,8 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
       basicTrace.getTraceIds().add(spanEsDO.getTraceId());
       traceBrief.getTraces().add(basicTrace);
     }
-    log.info("[apm] query_basic_traces finish, engine=elasticsearch, cost={}", stopWatch.getTime());
+    log.info("[apm] query_basic_traces finish, engine={}, cost={}", this.getClass().getSimpleName(),
+        stopWatch.getTime());
     return traceBrief;
   }
 
@@ -159,7 +157,7 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
     searchSourceBuilder.size(SPAN_QUERY_MAX_SIZE);
     SearchRequest searchRequest =
         new SearchRequest(new String[] {SpanDO.INDEX_NAME}, searchSourceBuilder);
-    SearchResponse searchResponse = esClient.search(searchRequest, RequestOptions.DEFAULT);
+    SearchResponse searchResponse = esClient().search(searchRequest, RequestOptions.DEFAULT);
     List<SpanDO> spanRecords = new ArrayList<>();
     for (org.elasticsearch.search.SearchHit hit : searchResponse.getHits().getHits()) {
       String hitJson = hit.getSourceAsString();
@@ -195,7 +193,8 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
       }
     });
     trace.getSpans().addAll(sortedSpans);
-    log.info("[apm] query_trace finish, engine=elasticsearch, cost={}", stopWatch.getTime());
+    log.info("[apm] query_trace finish, engine={}, cost={}", this.getClass().getSimpleName(),
+        stopWatch.getTime());
     return trace;
   }
 
@@ -242,7 +241,7 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
 
     SearchRequest searchRequest = new SearchRequest(SpanDO.INDEX_NAME);
     searchRequest.source(sourceBuilder);
-    SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
+    SearchResponse response = esClient().search(searchRequest, RequestOptions.DEFAULT);
 
     Terms terms = response.getAggregations().get(SpanDO.attributes(Const.APPID));
     for (Terms.Bucket bucket : terms.getBuckets()) {

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/ttl/EsDataCleaner.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/ttl/EsDataCleaner.java
@@ -35,6 +35,10 @@ public class EsDataCleaner implements DataCleaner {
   @Autowired
   private RestHighLevelClient esClient;
 
+  protected RestHighLevelClient esClient() {
+    return esClient;
+  }
+
   @Override
   public void clean(Model model) throws IOException {
     String name = model.getName();
@@ -45,7 +49,7 @@ public class EsDataCleaner implements DataCleaner {
       return;
     }
     GetAliasesResponse getAliasesResponse =
-        esClient.indices().getAlias(new GetAliasesRequest(name), RequestOptions.DEFAULT);
+        esClient().indices().getAlias(new GetAliasesRequest(name), RequestOptions.DEFAULT);
     Collection<String> indices = getAliasesResponse.getAliases().keySet();
     if (CollectionUtils.isNotEmpty(indices)) {
       for (String index : indices) {
@@ -56,7 +60,7 @@ public class EsDataCleaner implements DataCleaner {
         long indexTimeBucket = Long.parseLong(indexSuffix);
         if (deadline >= indexTimeBucket) {
           AcknowledgedResponse acknowledgedResponse =
-              esClient.indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT);
+              esClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT);
           if (acknowledgedResponse.isAcknowledged()) {
             this.indexLatestSuccess.put(name, deadline);
           }

--- a/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/initializer/ApmInitializer.java
+++ b/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/initializer/ApmInitializer.java
@@ -26,7 +26,6 @@ public class ApmInitializer implements ApplicationRunner {
       log.info("[apm] init finish");
     } catch (Exception e) {
       log.error("[apm] init fail, msg={}", e.getMessage(), e);
-      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
This PR is to make part of the code of Holoinsight can be reused to support more search engines compatible with the elasticsearch protocol.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Redefine the elasticsearch client from a variable `esClient` to an overridable method `esClient()`. 
- Revised some elasticsearch storage logs, the engine is no longer hard-coded but prints the simple name of the current class.
- Some codes of `ModelInstallerMananger` are optimized.
- The startup failure of the module APM no longer affects the startup of Holoinsight.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Validated on my local test environment.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
