### PR TITLE
feat(home): period alert detection mode

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -107,6 +107,8 @@ jobs:
           scene: scene-default
         - test: AlertRuleIT
           scene: scene-default
+        - test: AlertCalculateIT
+          scene: scene-default
     steps:
     - uses: actions/checkout@v3
       with:

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/function/FunctionConfigParam.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/function/FunctionConfigParam.java
@@ -3,6 +3,7 @@
  */
 package io.holoinsight.server.home.alert.model.function;
 
+import io.holoinsight.server.home.facade.emuns.PeriodType;
 import io.holoinsight.server.home.facade.trigger.CompareParam;
 import lombok.Data;
 
@@ -39,5 +40,9 @@ public class FunctionConfigParam {
 
   // zero fill to time series
   private boolean zeroFill;
+  // period type is used to compare past and present values or rate
+  private PeriodType periodType;
+  // trigger summary
+  private String triggerContent;
 
 }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AbstractUniformInspectRunningRule.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AbstractUniformInspectRunningRule.java
@@ -3,7 +3,6 @@
  */
 package io.holoinsight.server.home.alert.service.calculate;
 
-import io.holoinsight.server.common.J;
 import io.holoinsight.server.home.alert.common.G;
 import io.holoinsight.server.home.alert.model.compute.ComputeContext;
 import io.holoinsight.server.home.alert.model.compute.ComputeInfo;
@@ -152,7 +151,7 @@ public class AbstractUniformInspectRunningRule {
       ruleResult.setMetric(dataResult.getMetric());
       ruleResult.setTags(dataResult.getTags());
       ruleResult.setCompareParam(functionConfigParam.getCmp());
-      ruleResult.setTriggerContent(trigger.getTriggerContent());
+      ruleResult.setTriggerContent(functionConfigParam.getTriggerContent());
       ruleResult.setTriggerLevel(functionConfigParam.getTriggerLevel());
       triggerResults.add(ruleResult);
       if (ruleResult.isHit()) {
@@ -175,6 +174,7 @@ public class AbstractUniformInspectRunningRule {
       functionConfigAIParam.setStepTime(trigger.getDownsample());
       functionConfigAIParam.setTraceId(computeInfo.getTraceId());
       functionConfigAIParam.setTenant(computeInfo.getTenant());
+      functionConfigAIParam.setTriggerContent(trigger.getTriggerContent());
       functionConfigAIParam.setTrigger(trigger);
       list.add(functionConfigAIParam);
     } else {
@@ -188,6 +188,8 @@ public class AbstractUniformInspectRunningRule {
           functionConfigParam.setStepTime(trigger.getDownsample());
           functionConfigParam.setTraceId(computeInfo.getTraceId());
           functionConfigParam.setZeroFill(trigger.isZeroFill());
+          functionConfigParam.setPeriodType(trigger.getPeriodType());
+          functionConfigParam.setTriggerContent(compareConfig.getTriggerContent());
           list.add(functionConfigParam);
         }
       } else {
@@ -198,6 +200,8 @@ public class AbstractUniformInspectRunningRule {
         functionConfigParam.setStepTime(trigger.getDownsample());
         functionConfigParam.setTraceId(computeInfo.getTraceId());
         functionConfigParam.setZeroFill(trigger.isZeroFill());
+        functionConfigParam.setPeriodType(trigger.getPeriodType());
+        functionConfigParam.setTriggerContent(trigger.getTriggerContent());
         list.add(functionConfigParam);
       }
 

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/BaseFunction.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/BaseFunction.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.alert.service.calculate;
+
+import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;
+import io.holoinsight.server.home.alert.model.function.FunctionLogic;
+import io.holoinsight.server.home.facade.DataResult;
+import io.holoinsight.server.home.facade.emuns.PeriodType;
+import io.holoinsight.server.home.facade.trigger.CompareParam;
+import io.holoinsight.server.home.facade.trigger.TriggerResult;
+
+import java.util.Map;
+
+/**
+ * @author masaimu
+ * @version 2023-03-21 15:32:00
+ */
+public abstract class BaseFunction implements FunctionLogic {
+
+  protected Double rate(Double current, Double lastValue) {
+    if (Double.compare(current, 0d) == 0) {
+      return 0.0;
+    }
+    if (Double.compare(lastValue, 0d) == 0) {
+      return current > 0 ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY;
+    }
+    return (current - lastValue) / lastValue;
+  }
+
+  protected Double fillZero(boolean zeroFill, Double value) {
+    if (value == null && zeroFill) {
+      value = 0d;
+    }
+    return value;
+  }
+
+  protected Double fillOne(boolean zeroFill, Double value) {
+    if (value == null && zeroFill) {
+      value = 1d;
+    }
+    return value;
+  }
+
+  protected TriggerResult doInvoke(DataResult dataResult, FunctionConfigParam functionConfigParam) {
+    TriggerResult result = new TriggerResult();
+    result.setHit(false);
+
+    long delta = getDelta(functionConfigParam.getPeriodType());
+    Map<Long, Double> points = dataResult.getPoints();
+    result.setCurrentValue(points.get(functionConfigParam.getPeriod()));
+    long duration = functionConfigParam.getDuration();
+    for (long i = 0; i < duration; i++) {
+      long time = functionConfigParam.getPeriod() - i * 60000L;
+      Double current = fillZero(functionConfigParam.isZeroFill(), points.get(time));
+      Double past = fillZero(functionConfigParam.isZeroFill(), points.get(time - delta));
+      Double comparedValue = getComparedValue(current, past);
+      // comparedValue is null means rule has missed at this data point, the trigger condition can
+      // never be reached.
+      if (comparedValue == null) {
+        return result;
+      }
+      for (CompareParam cmp : functionConfigParam.getCmp()) {
+        double value = getValue(cmp);
+        boolean isHit = TriggerLogicNew.compareValue(cmp.getCmp(), value, comparedValue);
+        // comparedValue cannot hit means rule has missed at this data point
+        if (!isHit) {
+          return result;
+        }
+      }
+      result.getValues().put(time, current);
+    }
+    result.setHit(true);
+    return result;
+  }
+
+  private long getDelta(PeriodType periodType) {
+    if (periodType == null) {
+      return 0;
+    } else {
+      return periodType.intervalMillis();
+    }
+  }
+
+  protected abstract double getValue(CompareParam cmp);
+
+  protected abstract Double getComparedValue(Double current, Double past);
+}

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/FunctionManager.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/FunctionManager.java
@@ -7,6 +7,7 @@ package io.holoinsight.server.home.alert.service.calculate;
 import io.holoinsight.server.home.alert.model.function.FunctionLogic;
 import io.holoinsight.server.home.facade.emuns.FunctionEnum;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
@@ -26,6 +27,15 @@ public class FunctionManager implements InitializingBean {
   private Current current;
 
   @Resource
+  private PeriodAbs periodAbs;
+
+  @Resource
+  private PeriodValue periodValue;
+
+  @Resource
+  private PeriodRate periodRate;
+
+  @Resource
   private Step step;
 
   @Resource
@@ -41,6 +51,9 @@ public class FunctionManager implements InitializingBean {
   @Override
   public void afterPropertiesSet() {
     register(current);
+    register(periodRate);
+    register(periodValue);
+    register(periodAbs);
     register(step);
     register(valueUpAbnormalDetect);
     register(valueDownAbnormalDetect);

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/PeriodAbs.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/PeriodAbs.java
@@ -4,24 +4,21 @@
 package io.holoinsight.server.home.alert.service.calculate;
 
 import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;
-import io.holoinsight.server.home.alert.model.function.FunctionLogic;
 import io.holoinsight.server.home.facade.DataResult;
 import io.holoinsight.server.home.facade.emuns.FunctionEnum;
 import io.holoinsight.server.home.facade.trigger.CompareParam;
 import io.holoinsight.server.home.facade.trigger.TriggerResult;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-
 /**
- * @author wangsiyuan
- * @date 2022/11/25 9:54 AM
+ * @author masaimu
+ * @version 2023-03-21 14:37:00
  */
 @Service
-public class Current extends BaseFunction {
+public class PeriodAbs extends BaseFunction {
   @Override
   public FunctionEnum getFunc() {
-    return FunctionEnum.Current;
+    return FunctionEnum.PeriodAbs;
   }
 
   @Override
@@ -36,6 +33,9 @@ public class Current extends BaseFunction {
 
   @Override
   protected Double getComparedValue(Double current, Double past) {
-    return current;
+    if (current == null || past == null) {
+      return null;
+    }
+    return Math.abs(current - past);
   }
 }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/PeriodRate.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/PeriodRate.java
@@ -14,14 +14,14 @@ import org.springframework.stereotype.Service;
 import java.util.Map;
 
 /**
- * @author wangsiyuan
- * @date 2022/11/25 9:54 AM
+ * @author masaimu
+ * @version 2023-03-21 14:37:00
  */
 @Service
-public class Current extends BaseFunction {
+public class PeriodRate extends BaseFunction {
   @Override
   public FunctionEnum getFunc() {
-    return FunctionEnum.Current;
+    return FunctionEnum.PeriodRate;
   }
 
   @Override
@@ -31,11 +31,16 @@ public class Current extends BaseFunction {
 
   @Override
   protected double getValue(CompareParam cmp) {
-    return cmp.getCmpValue() == null ? 0d : cmp.getCmpValue();
+    double value = cmp.getCmpValue() == null ? 0d : cmp.getCmpValue();
+    value = value / 100;
+    return value;
   }
 
   @Override
   protected Double getComparedValue(Double current, Double past) {
-    return current;
+    if (current == null || past == null) {
+      return null;
+    }
+    return rate(current, past);
   }
 }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/PeriodValue.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/PeriodValue.java
@@ -4,7 +4,6 @@
 package io.holoinsight.server.home.alert.service.calculate;
 
 import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;
-import io.holoinsight.server.home.alert.model.function.FunctionLogic;
 import io.holoinsight.server.home.facade.DataResult;
 import io.holoinsight.server.home.facade.emuns.FunctionEnum;
 import io.holoinsight.server.home.facade.trigger.CompareParam;
@@ -14,14 +13,14 @@ import org.springframework.stereotype.Service;
 import java.util.Map;
 
 /**
- * @author wangsiyuan
- * @date 2022/11/25 9:54 AM
+ * @author masaimu
+ * @version 2023-03-21 14:37:00
  */
 @Service
-public class Current extends BaseFunction {
+public class PeriodValue extends BaseFunction {
   @Override
   public FunctionEnum getFunc() {
-    return FunctionEnum.Current;
+    return FunctionEnum.PeriodValue;
   }
 
   @Override
@@ -36,6 +35,9 @@ public class Current extends BaseFunction {
 
   @Override
   protected Double getComparedValue(Double current, Double past) {
-    return current;
+    if (current == null || past == null) {
+      return null;
+    }
+    return current - past;
   }
 }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/Step.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/Step.java
@@ -38,7 +38,7 @@ public class Step implements FunctionLogic {
       // 循环条件
       boolean isTrigger = true;
       for (CompareParam cmp : functionConfigParam.getCmp()) {
-        if (!TriggerLogicNew.compareValue(cmp, m.getValue())) {
+        if (!TriggerLogicNew.compareValue(cmp.getCmp(), cmp.getCmpValue(), m.getValue())) {
           isTrigger = false;
         }
       }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/TriggerLogicNew.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/TriggerLogicNew.java
@@ -14,9 +14,7 @@ import java.io.Serializable;
  */
 public class TriggerLogicNew implements Serializable {
 
-  public static boolean compareValue(CompareParam compareParam, Double value) {
-    CompareOperationEnum cmp = compareParam.getCmp();
-    Double cmpValue = compareParam.getCmpValue();
+  public static boolean compareValue(CompareOperationEnum cmp, Double cmpValue, Double value) {
     if (cmp == CompareOperationEnum.GT) {
       return value != null && value > cmpValue;
     } else if (cmp == CompareOperationEnum.GTE) {

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/CurrentTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/CurrentTest.java
@@ -16,8 +16,6 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-
 /**
  * @author masaimu
  * @version 2023-03-17 13:20:00
@@ -25,7 +23,7 @@ import static org.junit.Assert.*;
 public class CurrentTest {
 
   @Test
-  public void testInvoke() {
+  public void testZeroFill() {
     DataResult dataResult = new DataResult();
     Map<Long, Double> points = new LinkedHashMap<>();
     points.put(1678079340000L, 0d);
@@ -51,5 +49,55 @@ public class CurrentTest {
     functionConfigParam.setZeroFill(true);
     triggerResult = current.invoke(dataResult, functionConfigParam);
     Assert.assertTrue(triggerResult.isHit());
+  }
+
+  @Test
+  public void testHit() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079520000L, 14d);
+    points.put(1678079580000L, 10d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(10d);
+    compareParam.setCmp(CompareOperationEnum.GTE);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(3);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+
+    Current current = new Current();
+    TriggerResult triggerResult = current.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+  }
+
+  @Test
+  public void testMiss() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079520000L, 1d);
+    points.put(1678079580000L, 10d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(10d);
+    compareParam.setCmp(CompareOperationEnum.LT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(1);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+
+    Current current = new Current();
+    TriggerResult triggerResult = current.invoke(dataResult, functionConfigParam);
+    Assert.assertFalse(triggerResult.isHit());
   }
 }

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodAbsTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodAbsTest.java
@@ -1,0 +1,124 @@
+package io.holoinsight.server.home.alert.service.calculate;
+
+import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;
+import io.holoinsight.server.home.facade.DataResult;
+import io.holoinsight.server.home.facade.emuns.CompareOperationEnum;
+import io.holoinsight.server.home.facade.trigger.CompareParam;
+import io.holoinsight.server.home.facade.trigger.TriggerResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.holoinsight.server.home.facade.emuns.PeriodType.HOUR;
+import static io.holoinsight.server.home.facade.emuns.PeriodType.WEEK;
+
+/**
+ * @author masaimu
+ * @version 2023-03-23 16:59:00
+ */
+public class PeriodAbsTest {
+
+  @Test
+  public void testHit() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079520000L, 14d);
+    points.put(1678079580000L, 10d);
+
+    points.put(1678079340000L - HOUR.intervalMillis(), 110d);
+    points.put(1678079400000L - HOUR.intervalMillis(), 130d);
+    points.put(1678079460000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079520000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079580000L - HOUR.intervalMillis(), 100d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(50d);
+    compareParam.setCmp(CompareOperationEnum.GT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(3);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(HOUR);
+
+    PeriodAbs periodAbs = new PeriodAbs();
+    TriggerResult triggerResult = periodAbs.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+  }
+
+  @Test
+  public void testMiss() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079520000L, 14d);
+    points.put(1678079580000L, 10d);
+
+    points.put(1678079340000L - WEEK.intervalMillis(), 110d);
+    points.put(1678079400000L - WEEK.intervalMillis(), 130d);
+    points.put(1678079460000L - WEEK.intervalMillis(), 140d);
+    points.put(1678079520000L - WEEK.intervalMillis(), 140d);
+    points.put(1678079580000L - WEEK.intervalMillis(), 150d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(100d);
+    compareParam.setCmp(CompareOperationEnum.GT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(5);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(WEEK);
+
+    PeriodAbs periodAbs = new PeriodAbs();
+    TriggerResult triggerResult = periodAbs.invoke(dataResult, functionConfigParam);
+    Assert.assertFalse(triggerResult.isHit());
+  }
+
+  @Test
+  public void testZeroFill() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079580000L, 10d);
+
+    points.put(1678079340000L - HOUR.intervalMillis(), 110d);
+    points.put(1678079400000L - HOUR.intervalMillis(), 130d);
+    points.put(1678079460000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079520000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079580000L - HOUR.intervalMillis(), 100d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(50d);
+    compareParam.setCmp(CompareOperationEnum.GT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(3);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(HOUR);
+    functionConfigParam.setZeroFill(true);
+
+    PeriodAbs periodAbs = new PeriodAbs();
+    TriggerResult triggerResult = periodAbs.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+
+    functionConfigParam.setZeroFill(false);
+    triggerResult = periodAbs.invoke(dataResult, functionConfigParam);
+    Assert.assertFalse(triggerResult.isHit());
+  }
+
+}

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodAbsTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodAbsTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
 package io.holoinsight.server.home.alert.service.calculate;
 
 import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodRateTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodRateTest.java
@@ -1,0 +1,127 @@
+package io.holoinsight.server.home.alert.service.calculate;
+
+import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;
+import io.holoinsight.server.home.facade.DataResult;
+import io.holoinsight.server.home.facade.emuns.CompareOperationEnum;
+import io.holoinsight.server.home.facade.trigger.CompareParam;
+import io.holoinsight.server.home.facade.trigger.TriggerResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.holoinsight.server.home.facade.emuns.PeriodType.MINUTE;
+import static io.holoinsight.server.home.facade.emuns.PeriodType.QUARTER_HOUR;
+
+/**
+ * @author masaimu
+ * @version 2023-03-23 16:33:00
+ */
+public class PeriodRateTest {
+
+  @Test
+  public void testHit() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L - QUARTER_HOUR.intervalMillis(), 11d);
+    points.put(1678079400000L - QUARTER_HOUR.intervalMillis(), 13d);
+    points.put(1678079460000L - QUARTER_HOUR.intervalMillis(), 14d);
+    points.put(1678079520000L - QUARTER_HOUR.intervalMillis(), 14d);
+    points.put(1678079580000L - QUARTER_HOUR.intervalMillis(), 10d);
+
+    points.put(1678079340000L, 21d);
+    points.put(1678079400000L, 23d);
+    points.put(1678079460000L, 24d);
+    points.put(1678079520000L, 24d);
+    points.put(1678079580000L, 15d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(50d);
+    compareParam.setCmp(CompareOperationEnum.GTE);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(5);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(QUARTER_HOUR);
+
+    PeriodRate periodRate = new PeriodRate();
+    TriggerResult triggerResult = periodRate.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+  }
+
+  @Test
+  public void testMiss() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L - QUARTER_HOUR.intervalMillis(), 11d);
+    points.put(1678079400000L - QUARTER_HOUR.intervalMillis(), 13d);
+    points.put(1678079460000L - QUARTER_HOUR.intervalMillis(), 14d);
+    points.put(1678079520000L - QUARTER_HOUR.intervalMillis(), 14d);
+    points.put(1678079580000L - QUARTER_HOUR.intervalMillis(), 10d);
+
+    points.put(1678079340000L, 21d);
+    points.put(1678079400000L, 23d);
+    points.put(1678079460000L, 24d);
+    points.put(1678079520000L, 24d);
+    points.put(1678079580000L, 15d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(20d);
+    compareParam.setCmp(CompareOperationEnum.LT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(5);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(QUARTER_HOUR);
+
+    PeriodRate periodRate = new PeriodRate();
+    TriggerResult triggerResult = periodRate.invoke(dataResult, functionConfigParam);
+    Assert.assertFalse(triggerResult.isHit());
+  }
+
+  @Test
+  public void testZeroFill() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L - QUARTER_HOUR.intervalMillis(), 11d);
+    points.put(1678079400000L - QUARTER_HOUR.intervalMillis(), 13d);
+    points.put(1678079460000L - QUARTER_HOUR.intervalMillis(), 14d);
+    points.put(1678079580000L - QUARTER_HOUR.intervalMillis(), 10d);
+
+    points.put(1678079340000L, 21d);
+    points.put(1678079400000L, 23d);
+    points.put(1678079460000L, 24d);
+    points.put(1678079520000L, 24d);
+    points.put(1678079580000L, 15d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(50d);
+    compareParam.setCmp(CompareOperationEnum.GTE);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(3);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(QUARTER_HOUR);
+    functionConfigParam.setZeroFill(true);
+
+    PeriodRate periodRate = new PeriodRate();
+    TriggerResult triggerResult = periodRate.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+
+    functionConfigParam.setZeroFill(false);
+    triggerResult = periodRate.invoke(dataResult, functionConfigParam);
+    Assert.assertFalse(triggerResult.isHit());
+
+    functionConfigParam.setDuration(1);
+    triggerResult = periodRate.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+  }
+}

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodRateTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodRateTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
 package io.holoinsight.server.home.alert.service.calculate;
 
 import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodValueTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodValueTest.java
@@ -1,0 +1,124 @@
+package io.holoinsight.server.home.alert.service.calculate;
+
+import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;
+import io.holoinsight.server.home.facade.DataResult;
+import io.holoinsight.server.home.facade.emuns.CompareOperationEnum;
+import io.holoinsight.server.home.facade.trigger.CompareParam;
+import io.holoinsight.server.home.facade.trigger.TriggerResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.holoinsight.server.home.facade.emuns.PeriodType.HOUR;
+import static io.holoinsight.server.home.facade.emuns.PeriodType.WEEK;
+
+/**
+ * @author masaimu
+ * @version 2023-03-23 16:06:00
+ */
+public class PeriodValueTest {
+
+  @Test
+  public void testHit() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079520000L, 14d);
+    points.put(1678079580000L, 10d);
+
+    points.put(1678079340000L - HOUR.intervalMillis(), 110d);
+    points.put(1678079400000L - HOUR.intervalMillis(), 130d);
+    points.put(1678079460000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079520000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079580000L - HOUR.intervalMillis(), 100d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(-50d);
+    compareParam.setCmp(CompareOperationEnum.LT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(3);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(HOUR);
+
+    PeriodValue periodValue = new PeriodValue();
+    TriggerResult triggerResult = periodValue.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+  }
+
+  @Test
+  public void testMiss() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079520000L, 14d);
+    points.put(1678079580000L, 10d);
+
+    points.put(1678079340000L - WEEK.intervalMillis(), 110d);
+    points.put(1678079400000L - WEEK.intervalMillis(), 130d);
+    points.put(1678079460000L - WEEK.intervalMillis(), 140d);
+    points.put(1678079520000L - WEEK.intervalMillis(), 140d);
+    points.put(1678079580000L - WEEK.intervalMillis(), 150d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(-100d);
+    compareParam.setCmp(CompareOperationEnum.LT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(5);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(WEEK);
+
+    PeriodValue periodValue = new PeriodValue();
+    TriggerResult triggerResult = periodValue.invoke(dataResult, functionConfigParam);
+    Assert.assertFalse(triggerResult.isHit());
+  }
+
+  @Test
+  public void testZeroFill() {
+    DataResult dataResult = new DataResult();
+    Map<Long, Double> points = new LinkedHashMap<>();
+    points.put(1678079340000L, 11d);
+    points.put(1678079400000L, 13d);
+    points.put(1678079460000L, 14d);
+    points.put(1678079580000L, 10d);
+
+    points.put(1678079340000L - HOUR.intervalMillis(), 110d);
+    points.put(1678079400000L - HOUR.intervalMillis(), 130d);
+    points.put(1678079460000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079520000L - HOUR.intervalMillis(), 140d);
+    points.put(1678079580000L - HOUR.intervalMillis(), 100d);
+    dataResult.setPoints(points);
+
+    CompareParam compareParam = new CompareParam();
+    compareParam.setCmpValue(-50d);
+    compareParam.setCmp(CompareOperationEnum.LT);
+
+    FunctionConfigParam functionConfigParam = new FunctionConfigParam();
+    functionConfigParam.setPeriod(1678079580000L);
+    functionConfigParam.setDuration(3);
+    functionConfigParam.setCmp(Arrays.asList(compareParam));
+    functionConfigParam.setPeriodType(HOUR);
+    functionConfigParam.setZeroFill(true);
+
+    PeriodValue periodValue = new PeriodValue();
+    TriggerResult triggerResult = periodValue.invoke(dataResult, functionConfigParam);
+    Assert.assertTrue(triggerResult.isHit());
+
+    functionConfigParam.setZeroFill(false);
+    triggerResult = periodValue.invoke(dataResult, functionConfigParam);
+    Assert.assertFalse(triggerResult.isHit());
+  }
+
+}

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodValueTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodValueTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
 package io.holoinsight.server.home.alert.service.calculate;
 
 import io.holoinsight.server.home.alert.model.function.FunctionConfigParam;

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/DataResult.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/DataResult.java
@@ -4,9 +4,15 @@
 package io.holoinsight.server.home.facade;
 
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.CollectionUtils;
 
 import java.io.Serializable;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
 
 /**
  * @author wangsiyuan
@@ -21,4 +27,20 @@ public class DataResult implements Serializable {
 
   private Map<Long, Double> points;
 
+  public String getKey() {
+    if (StringUtils.isEmpty(metric)) {
+      return StringUtils.EMPTY;
+    }
+    StringBuilder key = new StringBuilder(metric);
+    if (!CollectionUtils.isEmpty(tags)) {
+      TreeMap<String, String> sortedMap = new TreeMap<>(tags);
+      for (Map.Entry<String, String> entry : sortedMap.entrySet()) {
+        key.append(entry.getKey()) //
+            .append(":") //
+            .append(entry.getValue()) //
+            .append(",");
+      }
+    }
+    return key.toString();
+  }
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/FunctionEnum.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/FunctionEnum.java
@@ -9,8 +9,13 @@ package io.holoinsight.server.home.facade.emuns;
  */
 public enum FunctionEnum {
 
-  Current("Current", "当前时间值", "RULE"), Step("Step", "周期时间比较", "RULE"), ValueUp("ValueUp", "值上涨",
-      "AI"), ValueDown("ValueDown", "值下跌", "AI");
+  Current("Current", "当前时间值", "RULE"), //
+  PeriodRate("PeriodRate", "同环比比例", "RULE"), //
+  PeriodValue("PeriodValue", "同环比差值", "RULE"), //
+  PeriodAbs("PeriodAbv", "同环比绝对值", "RULE"), //
+  Step("Step", "周期时间比较", "RULE"), //
+  ValueUp("ValueUp", "值上涨", "AI"), //
+  ValueDown("ValueDown", "值下跌", "AI");
 
   private final String code;
 

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/PeriodType.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/PeriodType.java
@@ -10,8 +10,12 @@ public enum PeriodType {
   SECOND(1000, "1s"), //
   FIVE_SECOND(5000, "5s"), //
   MINUTE(60000, "1min"), //
+  FIVE_MINUTE(5 * 60000, "5min"), //
+  QUARTER_HOUR(15 * 60000, "15min"), //
+  HALF_HOUR(30 * 60000, "30min"), //
   HOUR(60 * 60 * 1000, "1hour"), //
-  DAY(24 * 60 * 60 * 1000, "1day"), WEEK(7 * 24 * 60 * 60 * 1000, "1week");
+  DAY(24 * 60 * 60 * 1000, "1day"), //
+  WEEK(7 * 24 * 60 * 60 * 1000, "1week");
 
   private final int intervalMillis;
   private final String desc;

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/CompareConfig.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/CompareConfig.java
@@ -16,4 +16,7 @@ public class CompareConfig {
 
   private List<CompareParam> compareParam; // 触发条件
   private String triggerLevel;
+
+  // trigger summary
+  private String triggerContent;
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/Trigger.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/Trigger.java
@@ -5,6 +5,7 @@ package io.holoinsight.server.home.facade.trigger;
 
 import io.holoinsight.server.home.facade.DataResult;
 import io.holoinsight.server.home.facade.emuns.FunctionEnum;
+import io.holoinsight.server.home.facade.emuns.PeriodType;
 import lombok.Data;
 
 import java.util.List;
@@ -51,5 +52,7 @@ public class Trigger {
 
   // zero fill
   private boolean zeroFill;
+  // period type
+  private PeriodType periodType;
 
 }

--- a/test/scenes/scene-default/after.sh
+++ b/test/scenes/scene-default/after.sh
@@ -26,3 +26,6 @@ docker exec $server_container_name bash -c 'sc reread && sleep 1 && sc add agent
 echo copy log-generator.py to $server_container_name
 docker cp ./log-generator.py $server_container_name:/home/admin/logs/holoinsight-server/log-generator.py
 docker exec -w /home/admin/logs/holoinsight-server $server_container_name bash -c ' python log-generator.py & '
+
+docker cp ./log-alert-generator.py $server_container_name:/home/admin/logs/holoinsight-server/log-alert-generator.py
+docker exec -w /home/admin/logs/holoinsight-server $server_container_name bash -c ' python log-alert-generator.py & '

--- a/test/scenes/scene-default/log-alert-generator.py
+++ b/test/scenes/scene-default/log-alert-generator.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+import atexit
+import datetime
+import sched
+import time
+
+s = sched.scheduler(time.time, time.sleep)
+
+
+def schedule_with_fixed_rate(init_delay, interval, action, args):
+    def wrapper(*args2):
+        action()
+        now = datetime.datetime.now()
+        next_align_time = datetime.datetime.now().replace(microsecond=0) + datetime.timedelta(seconds=interval)
+        delta = next_align_time - now
+        s.enter(delta.total_seconds(), 1, wrapper, args2)
+
+    s.enter(init_delay, 1, wrapper, args)
+
+
+log1 = open('increase_value.log', mode='a')
+atexit.register(log1.close)
+
+start = int(time.time())
+def task1(*args):
+    time_str = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    cur = int(time.time())
+    log1.write('%s level=%s biz=[biz1] cost=%dms\n' % (time_str, 'INFO', cur-start))
+    log1.flush()
+
+
+schedule_with_fixed_rate(0, 1, task1, ())
+
+s.run()

--- a/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/AlertCalculateIT.java
+++ b/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/AlertCalculateIT.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2023 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.test.it;
+
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.home.facade.AlarmHistoryDTO;
+import io.holoinsight.server.home.facade.AlarmRuleDTO;
+import io.holoinsight.server.home.facade.Rule;
+import io.holoinsight.server.home.facade.TimeFilter;
+import io.holoinsight.server.home.facade.emuns.BoolOperationEnum;
+import io.holoinsight.server.home.facade.emuns.CompareOperationEnum;
+import io.holoinsight.server.home.facade.emuns.FunctionEnum;
+import io.holoinsight.server.home.facade.emuns.PeriodType;
+import io.holoinsight.server.home.facade.emuns.TimeFilterEnum;
+import io.holoinsight.server.home.facade.page.MonitorPageRequest;
+import io.holoinsight.server.home.facade.trigger.CompareConfig;
+import io.holoinsight.server.home.facade.trigger.CompareParam;
+import io.holoinsight.server.home.facade.trigger.DataSource;
+import io.holoinsight.server.home.facade.trigger.Trigger;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author masaimu
+ * @version 2023-03-23 17:08:00
+ */
+public class AlertCalculateIT extends BaseIT {
+
+  Long currentId;
+  Long periodValueId;
+  Long periodRateId;
+  Long periodAbsId;
+  Long cpId;
+  String metricName;
+
+  @Order(1)
+  @Test
+  public void test_rule_calculate() {
+    String name = RandomStringUtils.randomAlphabetic(6);
+
+    JSONObject body = getJsonFromClasspath("requests/AlertCalculateIT.json");
+    body.put("name", body.get("name") + name);
+    // Create log monitoring
+    cpId = ((Number) given() //
+        .body(body) //
+        .when() //
+        .post("/webapi/customPlugin/create") //
+        .then() //
+        .body("success", IS_TRUE) //
+        .extract() //
+        .path("data.id")) //
+            .longValue(); //
+
+    metricName = "cost_" + cpId;
+
+    AlarmRuleDTO currentAlarmRule = new AlarmRuleDTO();
+    currentAlarmRule.setRuleName("current告警规则测试");
+    currentAlarmRule.setSourceType("log");
+    currentAlarmRule.setSourceId(cpId);
+    currentAlarmRule.setAlarmLevel("5");
+    currentAlarmRule.setRuleDescribe("测试告警规则");
+    currentAlarmRule.setStatus((byte) 1);
+    currentAlarmRule.setIsMerge((byte) 0);
+    currentAlarmRule.setRecover((byte) 0);
+    currentAlarmRule.setRuleType("rule");
+    currentAlarmRule.setTimeFilter(buildTimeFilter());
+    currentAlarmRule.setRule(buildCurrentRule());
+
+    // Create current alert
+    currentId = ((Number) given() //
+        .body(new JSONObject(J.toMap(J.toJson(currentAlarmRule)))) //
+        .when() //
+        .post("/webapi/alarmRule/create") //
+        .then() //
+        .body("success", IS_TRUE) //
+        .body("data", Matchers.any(Number.class)) //
+        .extract() //
+        .path("data")) //
+            .longValue(); //
+    System.out.println(currentId);
+
+    AlarmRuleDTO periodValueAlarmRule = new AlarmRuleDTO();
+    periodValueAlarmRule.setRuleName("periodValue告警规则测试");
+    periodValueAlarmRule.setSourceType("log");
+    periodValueAlarmRule.setSourceId(cpId);
+    periodValueAlarmRule.setAlarmLevel("5");
+    periodValueAlarmRule.setRuleDescribe("测试告警规则");
+    periodValueAlarmRule.setStatus((byte) 1);
+    periodValueAlarmRule.setIsMerge((byte) 0);
+    periodValueAlarmRule.setRecover((byte) 0);
+    periodValueAlarmRule.setRuleType("rule");
+    periodValueAlarmRule.setTimeFilter(buildTimeFilter());
+    periodValueAlarmRule.setRule(buildPeriodValueRule());
+
+    // Create period value alert
+    periodValueId = ((Number) given() //
+        .body(new JSONObject(J.toMap(J.toJson(periodValueAlarmRule)))) //
+        .when() //
+        .post("/webapi/alarmRule/create") //
+        .then() //
+        .body("success", IS_TRUE) //
+        .body("data", Matchers.any(Number.class)) //
+        .extract() //
+        .path("data")) //
+            .longValue(); //
+    System.out.println(periodValueId);
+
+    AlarmRuleDTO periodRateAlarmRule = new AlarmRuleDTO();
+    periodRateAlarmRule.setRuleName("periodRate告警规则测试");
+    periodRateAlarmRule.setSourceType("log");
+    periodRateAlarmRule.setSourceId(cpId);
+    periodRateAlarmRule.setAlarmLevel("5");
+    periodRateAlarmRule.setRuleDescribe("测试告警规则");
+    periodRateAlarmRule.setStatus((byte) 1);
+    periodRateAlarmRule.setIsMerge((byte) 0);
+    periodRateAlarmRule.setRecover((byte) 0);
+    periodRateAlarmRule.setRuleType("rule");
+    periodRateAlarmRule.setTimeFilter(buildTimeFilter());
+    periodRateAlarmRule.setRule(buildPeriodRateRule());
+
+    // Create period rate alert
+    periodRateId = ((Number) given() //
+        .body(new JSONObject(J.toMap(J.toJson(periodRateAlarmRule)))) //
+        .when() //
+        .post("/webapi/alarmRule/create") //
+        .then() //
+        .body("success", IS_TRUE) //
+        .body("data", Matchers.any(Number.class)) //
+        .extract() //
+        .path("data")) //
+            .longValue(); //
+    System.out.println(periodRateId);
+
+    AlarmRuleDTO periodAbsAlarmRule = new AlarmRuleDTO();
+    periodAbsAlarmRule.setRuleName("periodAbs告警规则测试");
+    periodAbsAlarmRule.setSourceType("log");
+    periodAbsAlarmRule.setSourceId(cpId);
+    periodAbsAlarmRule.setAlarmLevel("5");
+    periodAbsAlarmRule.setRuleDescribe("测试告警规则");
+    periodAbsAlarmRule.setStatus((byte) 1);
+    periodAbsAlarmRule.setIsMerge((byte) 0);
+    periodAbsAlarmRule.setRecover((byte) 0);
+    periodAbsAlarmRule.setRuleType("rule");
+    periodAbsAlarmRule.setTimeFilter(buildTimeFilter());
+    periodAbsAlarmRule.setRule(buildPeriodAbsRule());
+
+    // Create period abs alert
+    periodAbsId = ((Number) given() //
+        .body(new JSONObject(J.toMap(J.toJson(periodAbsAlarmRule)))) //
+        .when() //
+        .post("/webapi/alarmRule/create") //
+        .then() //
+        .body("success", IS_TRUE) //
+        .body("data", Matchers.any(Number.class)) //
+        .extract() //
+        .path("data")) //
+            .longValue(); //
+    System.out.println(periodAbsId);
+
+    await("Alert history generation") //
+        .atMost(Duration.ofMinutes(10)) //
+        .untilAsserted(() -> {
+          AlarmHistoryDTO condition = new AlarmHistoryDTO();
+          condition.setUniqueId("rule_" + currentId);
+          MonitorPageRequest<AlarmHistoryDTO> pageRequest = new MonitorPageRequest<>();
+          pageRequest.setTarget(condition);
+          pageRequest.setPageNum(0);
+          pageRequest.setPageSize(3);
+          given() //
+              .body(new JSONObject(J.toMap(J.toJson(pageRequest)))) //
+              .when() //
+              .post("/webapi/alarmHistory/pageQuery") //
+              .then() //
+              .body("success", IS_TRUE) //
+              .body("data.items.size()", gt(0));
+
+          condition = new AlarmHistoryDTO();
+          condition.setUniqueId("rule_" + periodValueId);
+          pageRequest = new MonitorPageRequest<>();
+          pageRequest.setTarget(condition);
+          pageRequest.setPageNum(0);
+          pageRequest.setPageSize(3);
+          given() //
+              .body(new JSONObject(J.toMap(J.toJson(pageRequest)))) //
+              .when() //
+              .post("/webapi/alarmHistory/pageQuery") //
+              .then() //
+              .body("success", IS_TRUE) //
+              .body("data.items.size()", gt(0));
+
+          condition = new AlarmHistoryDTO();
+          condition.setUniqueId("rule_" + periodAbsId);
+          pageRequest = new MonitorPageRequest<>();
+          pageRequest.setTarget(condition);
+          pageRequest.setPageNum(0);
+          pageRequest.setPageSize(3);
+          given() //
+              .body(new JSONObject(J.toMap(J.toJson(pageRequest)))) //
+              .when() //
+              .post("/webapi/alarmHistory/pageQuery") //
+              .then() //
+              .body("success", IS_TRUE) //
+              .body("data.items.size()", gt(0));
+
+          condition = new AlarmHistoryDTO();
+          condition.setUniqueId("rule_" + periodRateId);
+          pageRequest = new MonitorPageRequest<>();
+          pageRequest.setTarget(condition);
+          pageRequest.setPageNum(0);
+          pageRequest.setPageSize(3);
+          given() //
+              .body(new JSONObject(J.toMap(J.toJson(pageRequest)))) //
+              .when() //
+              .post("/webapi/alarmHistory/pageQuery") //
+              .then() //
+              .body("success", IS_TRUE) //
+              .body("data.items.size()", gt(0));
+        });
+  }
+
+  private Map<String, Object> buildPeriodAbsRule() {
+    Rule rule = new Rule();
+    rule.setBoolOperation(BoolOperationEnum.AND);
+    rule.setTriggers(Collections.singletonList(buildPeriodAbsTrigger()));
+    return J.toMap(J.toJson(rule));
+  }
+
+  private Trigger buildPeriodAbsTrigger() {
+    Trigger trigger = new Trigger();
+    trigger.setZeroFill(true);
+    trigger.setQuery("a");
+    trigger.setType(FunctionEnum.PeriodAbs);
+    trigger.setStepNum(1);
+    trigger.setAggregator("avg");
+    trigger.setDownsample(2L);
+    trigger.setCompareConfigs(
+        Collections.singletonList(buildCompareConfig("periodAbs alert test", 10)));
+    trigger.setDatasources(Collections.singletonList(buildDataSource()));
+    trigger.setPeriodType(PeriodType.MINUTE);
+    return trigger;
+  }
+
+  private Map<String, Object> buildPeriodRateRule() {
+    Rule rule = new Rule();
+    rule.setBoolOperation(BoolOperationEnum.AND);
+    rule.setTriggers(Collections.singletonList(buildPeriodRateTrigger()));
+    return J.toMap(J.toJson(rule));
+  }
+
+  private Trigger buildPeriodRateTrigger() {
+    Trigger trigger = new Trigger();
+    trigger.setZeroFill(true);
+    trigger.setQuery("a");
+    trigger.setType(FunctionEnum.PeriodRate);
+    trigger.setStepNum(1);
+    trigger.setAggregator("avg");
+    trigger.setDownsample(2L);
+    trigger.setCompareConfigs(
+        Collections.singletonList(buildCompareConfig("periodRate alert test", 0.1)));
+    trigger.setDatasources(Collections.singletonList(buildDataSource()));
+    trigger.setPeriodType(PeriodType.MINUTE);
+    return trigger;
+  }
+
+  private Map<String, Object> buildPeriodValueRule() {
+    Rule rule = new Rule();
+    rule.setBoolOperation(BoolOperationEnum.AND);
+    rule.setTriggers(Collections.singletonList(buildPeriodValueTrigger()));
+    return J.toMap(J.toJson(rule));
+  }
+
+  private Trigger buildPeriodValueTrigger() {
+    Trigger trigger = new Trigger();
+    trigger.setZeroFill(true);
+    trigger.setQuery("a");
+    trigger.setType(FunctionEnum.PeriodValue);
+    trigger.setStepNum(1);
+    trigger.setAggregator("avg");
+    trigger.setDownsample(2L);
+    trigger.setCompareConfigs(
+        Collections.singletonList(buildCompareConfig("periodValue alert test", 10)));
+    trigger.setDatasources(Collections.singletonList(buildDataSource()));
+    trigger.setPeriodType(PeriodType.MINUTE);
+    return trigger;
+  }
+
+  private Map<String, Object> buildCurrentRule() {
+    Rule rule = new Rule();
+    rule.setBoolOperation(BoolOperationEnum.AND);
+    rule.setTriggers(Collections.singletonList(buildCurrentTrigger()));
+    return J.toMap(J.toJson(rule));
+  }
+
+  private Trigger buildCurrentTrigger() {
+    Trigger trigger = new Trigger();
+    trigger.setZeroFill(true);
+    trigger.setQuery("a");
+    trigger.setType(FunctionEnum.Current);
+    trigger.setStepNum(1);
+    trigger.setAggregator("avg");
+    trigger.setDownsample(2L);
+    trigger.setTriggerTitle("触发条件 title");
+    trigger.setCompareConfigs(
+        Collections.singletonList(buildCompareConfig("current alert test", 1000)));
+    trigger.setDatasources(Collections.singletonList(buildDataSource()));
+    return trigger;
+  }
+
+  private DataSource buildDataSource() {
+    DataSource dataSource = new DataSource();
+    dataSource.setMetricType("log");
+    dataSource.setMetric(metricName);
+    dataSource.setName("a");
+    dataSource.setAggregator("none");
+    return dataSource;
+  }
+
+  private CompareConfig buildCompareConfig(String triggerContent, double cmpValue) {
+    CompareConfig compareConfig = new CompareConfig();
+    compareConfig.setTriggerLevel("4");
+    compareConfig.setCompareParam(Collections.singletonList(buildCompareParam(cmpValue)));
+    compareConfig.setTriggerContent(triggerContent);
+    return compareConfig;
+  }
+
+  private Map<String, Object> buildTimeFilter() {
+    TimeFilter timeFilter = new TimeFilter();
+    timeFilter.setModel(TimeFilterEnum.DAY.getDesc());
+    timeFilter.setFrom("00:00:00");
+    timeFilter.setTo("23:59:59");
+    timeFilter.setWeeks(Collections.emptyList());
+    return J.toMap(J.toJson(timeFilter));
+  }
+
+  private CompareParam buildCompareParam(double cmpValue) {
+    CompareParam param = new CompareParam();
+    param.setCmp(CompareOperationEnum.GT);
+    param.setCmpValue(cmpValue);
+    return param;
+  }
+}

--- a/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/AlertCalculateIT.java
+++ b/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/AlertCalculateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Holoinsight Project Authors. Licensed under Apache-2.0.
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
  */
 package io.holoinsight.server.test.it;
 

--- a/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/bootstrap/ITSets.java
+++ b/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/bootstrap/ITSets.java
@@ -5,6 +5,7 @@ package io.holoinsight.server.test.it.bootstrap;
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
+import io.holoinsight.server.test.it.AlertCalculateIT;
 import io.holoinsight.server.test.it.AlertRuleIT;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -37,6 +38,7 @@ public class ITSets {
         .selectors(selectClass(AgentVMIT.class)) //
         .selectors(selectClass(LogMonitoringIT.class)) //
         .selectors(selectClass(AlertRuleIT.class)) //
+        .selectors(selectClass(AlertCalculateIT.class)) //
         .build(); //
   }
 }

--- a/test/server-e2e-test/src/test/resources/requests/AlertCalculateIT.json
+++ b/test/server-e2e-test/src/test/resources/requests/AlertCalculateIT.json
@@ -1,0 +1,104 @@
+{
+  "name": "告警算子测试用日志监控",
+  "parentFolderId": "-1",
+  "pluginType": "custom",
+  "status": "ONLINE",
+  "periodType": "FIVE_SECOND",
+  "sampleLog": "2023-03-23 18:31:35 level=INFO biz=[biz1] cost=348ms",
+  "conf":
+  {
+    "collectRanges":
+    {
+      "table": "default_server",
+      "condition":
+      [
+        {
+          "app":
+          [
+            "holoinsight-server-example"
+          ]
+        }
+      ]
+    },
+    "logPaths":
+    [
+      {
+        "path": "/home/admin/logs/holoinsight-server/increase_value.log",
+        "type": "path",
+        "charset": "utf-8",
+        "agentLimitKB": -1
+      }
+    ],
+    "logParse":
+    {
+      "splitType": "LR",
+      "separator": null,
+      "regexp": null,
+      "multiLine":
+      {
+        "multi": false
+      }
+    },
+    "whiteFilters":
+    [],
+    "blackFilters":
+    [],
+    "splitCols":
+    [
+      {
+        "name": "cost",
+        "colType": "VALUE",
+        "rule":
+        {
+          "left": "cost=",
+          "right": "ms",
+          "leftIndex": 0,
+          "nullable": false,
+          "defaultValue": "",
+          "translate":
+          {
+            "exprs":
+            [],
+            "defaultValue": ""
+          }
+        }
+      },
+      {
+        "name": "biz_name",
+        "colType": "DIM",
+        "rule":
+        {
+          "left": "[",
+          "right": "]",
+          "leftIndex": 0,
+          "nullable": true,
+          "defaultValue": "",
+          "translate":
+          {
+            "exprs":
+            [],
+            "defaultValue": ""
+          }
+        }
+      }
+    ],
+    "collectMetrics":
+    [
+      {
+        "metricType": "select",
+        "tags":
+        [
+          "biz_name"
+        ],
+        "metrics":
+        [
+          {
+            "name": "cost",
+            "func": "sum"
+          }
+        ],
+        "tableName": "cost"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #270 


# What changes are included in this PR?

- `PeriodValue`: Detection of the rise and fall difference.
- `PeriodRate`: Detection of the rise and fall ratio relative to past values.
- `PeriodAbs`: Detection of the absolute value of the rise and fall difference.

# Are there any user-facing changes?

User can choose more alert detection modes.

# How does this change test

E2E: `test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/AlertCalculateIT.java`
Unit tests:
- `server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/CurrentTest.java`
- `server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodAbsTest.java`
- `server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodValueTest.java`
- `server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/PeriodRateTest.java`
