### PR TITLE
feat(home): alarm hosting plugin

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -109,6 +109,8 @@ jobs:
           scene: scene-default
         - test: AlertCalculateIT
           scene: scene-default
+        - test: IntegrationPluginIT
+          scene: scene-default
     steps:
     - uses: actions/checkout@v3
       with:

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/AbstractHostingAlertPlugin.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/AbstractHostingAlertPlugin.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.biz.plugin;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.google.gson.reflect.TypeToken;
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.home.biz.plugin.model.HostingAlertList;
+import io.holoinsight.server.home.biz.plugin.model.HostingPlugin;
+import io.holoinsight.server.home.biz.service.AlertRuleService;
+import io.holoinsight.server.home.biz.service.IntegrationProductService;
+import io.holoinsight.server.home.dal.mapper.AlarmSubscribeMapper;
+import io.holoinsight.server.home.dal.mapper.AlarmWebhookMapper;
+import io.holoinsight.server.home.dal.model.AlarmSubscribe;
+import io.holoinsight.server.home.dal.model.AlarmWebhook;
+import io.holoinsight.server.home.dal.model.dto.IntegrationPluginDTO;
+import io.holoinsight.server.home.dal.model.dto.IntegrationProductDTO;
+import io.holoinsight.server.home.facade.AlarmRuleDTO;
+import io.holoinsight.server.home.facade.page.MonitorPageRequest;
+import io.holoinsight.server.home.facade.page.MonitorPageResult;
+import io.holoinsight.server.home.facade.trigger.Filter;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.CollectionUtils;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author masaimu
+ * @version 2023-02-27 21:06:00
+ */
+public abstract class AbstractHostingAlertPlugin extends HostingPlugin {
+
+  @Autowired
+  public AlertRuleService alertRuleService;
+
+  @Resource
+  private AlarmWebhookMapper alarmWebhookMapper;
+
+  @Resource
+  private AlarmSubscribeMapper alarmSubscribeMapper;
+
+  @Autowired
+  private IntegrationProductService productService;
+
+  protected void enableAlertHosting(IntegrationProductDTO product,
+      IntegrationPluginDTO integrationPluginDTO) {
+    String configuration = product.configuration;
+    if (StringUtils.isEmpty(configuration)) {
+      return;
+    }
+    HostingAlertList hostingAlertList =
+        J.fromJson(configuration, new TypeToken<HostingAlertList>() {}.getType());
+
+    List<AlarmRuleDTO> alarmRuleDTOList = hostingAlertList.parseAlertRule(product,
+        integrationPluginDTO, buildFilter(integrationPluginDTO), getSourceType());
+    Map<Long, AlarmRuleDTO> ids = new HashMap<>();
+    for (AlarmRuleDTO alarmRuleDTO : alarmRuleDTOList) {
+      Long id = this.alertRuleService.save(alarmRuleDTO);
+      ids.put(id, alarmRuleDTO);
+    }
+    List<AlarmWebhook> webhooks = getWebhookConfig(integrationPluginDTO.tenant);
+    if (!CollectionUtils.isEmpty(webhooks)) {
+      for (AlarmWebhook alarmWebhook : webhooks) {
+        enableAlertSubscribe(alarmWebhook, ids);
+      }
+    }
+  }
+
+  private void enableAlertSubscribe(AlarmWebhook alarmWebhook, Map<Long, AlarmRuleDTO> ruleIds) {
+    if (CollectionUtils.isEmpty(ruleIds)) {
+      return;
+    }
+    for (Map.Entry<Long, AlarmRuleDTO> entry : ruleIds.entrySet()) {
+      AlarmRuleDTO rule = entry.getValue();
+      String uniqueId = rule.getRuleType() + "_" + entry.getKey();
+      AlarmSubscribe alarmSubscribe = new AlarmSubscribe();
+      alarmSubscribe.setCreator(alarmWebhook.getCreator());
+      alarmSubscribe.setGroupId(alarmWebhook.getId());
+      alarmSubscribe.setUniqueId(uniqueId);
+      alarmSubscribe.setNoticeType("[\"webhook\"]");
+      alarmSubscribe.setStatus((byte) 1);
+      alarmSubscribe.setTenant(alarmWebhook.getTenant());
+      alarmSubscribe.setEnvType(rule.getEnvType());
+      this.alarmSubscribeMapper.insert(alarmSubscribe);
+    }
+  }
+
+  private List<AlarmWebhook> getWebhookConfig(String tenant) {
+    QueryWrapper<AlarmWebhook> queryWrapper = new QueryWrapper<>();
+    queryWrapper.eq("role", "hosting");
+    queryWrapper.eq("tenant", tenant);
+    return this.alarmWebhookMapper.selectList(queryWrapper);
+  }
+
+  private List<Filter> buildFilter(IntegrationPluginDTO newPlugin) {
+    Map<String, Object> collectRange = newPlugin.getCollectRange();
+    if (CollectionUtils.isEmpty(collectRange)) {
+      return Collections.emptyList();
+    }
+    IntegrationPluginDTO.DataRange dataRange =
+        J.fromJson(J.toJson(collectRange), IntegrationPluginDTO.DataRange.class);
+    if (CollectionUtils.isEmpty(dataRange.getValuesMap())) {
+      return Collections.emptyList();
+    }
+    List<Filter> list = new ArrayList<>();
+
+    for (Map.Entry<String, String> entry : dataRange.getValuesMap().entrySet()) {
+      String key = entry.getKey();
+      Filter filter = new Filter();
+      filter.setName(key);
+      filter.setValue(entry.getValue());
+      filter.setType("literal_or");
+      list.add(filter);
+    }
+    return list;
+  }
+
+  protected boolean disableAlertHosting(IntegrationPluginDTO disableIntegrationPlugin) {
+    Long id = disableIntegrationPlugin.id;
+    if (id == null) {
+      return true;
+    }
+
+    AlarmRuleDTO condition = new AlarmRuleDTO();
+    condition.setSourceId(id);
+    MonitorPageRequest<AlarmRuleDTO> request = new MonitorPageRequest<>();
+    request.setTarget(condition);
+    request.setPageSize(1000);
+    MonitorPageResult<AlarmRuleDTO> result = this.alertRuleService.getListByPage(request);
+    if (CollectionUtils.isEmpty(result.getItems())) {
+      return true;
+    }
+    for (AlarmRuleDTO alarmRuleDTO : result.getItems()) {
+      if (invalidTenant(alarmRuleDTO, disableIntegrationPlugin)) {
+        continue;
+      }
+      AlarmRuleDTO updateEntity = new AlarmRuleDTO();
+      updateEntity.setId(alarmRuleDTO.getId());
+      updateEntity.setStatus((byte) 0);
+      this.alertRuleService.updateById(updateEntity);
+    }
+    return true;
+  }
+
+  protected abstract boolean invalidTenant(AlarmRuleDTO alarmRuleDTO,
+      IntegrationPluginDTO disableIntegrationPlugin);
+
+
+  @Override
+  public IntegrationPluginDTO apply(IntegrationPluginDTO integrationPlugin) {
+    if (integrationPlugin == null) {
+      return null;
+    }
+
+    Map<String, Object> productCondition = new HashMap<>();
+    productCondition.put("name", integrationPlugin.product);
+    productCondition.put("type", getProductType());
+    productCondition.put("version", integrationPlugin.version);
+    List<IntegrationProductDTO> existingProductList =
+        this.productService.findByMap(productCondition);
+    if (CollectionUtils.isEmpty(existingProductList)) {
+      return null;
+    }
+
+    IntegrationProductDTO product = existingProductList.get(0);
+
+    disableAlertHosting(integrationPlugin);
+    enableAlertHosting(product, integrationPlugin);
+
+    return integrationPlugin;
+  }
+
+  protected abstract String getProductType();
+
+  public abstract String getSourceType();
+}

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/DefaultHostingAlertPlugin.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/DefaultHostingAlertPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.biz.plugin.model;
+
+import io.holoinsight.server.home.biz.plugin.AbstractHostingAlertPlugin;
+import io.holoinsight.server.home.dal.model.dto.IntegrationPluginDTO;
+import io.holoinsight.server.home.facade.AlarmRuleDTO;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author masaimu
+ * @version 2023-03-24 16:30:00
+ */
+@Component
+@PluginModel(name = DefaultHostingAlertPlugin.HOSTING_AI_ALERT, version = "1")
+public class DefaultHostingAlertPlugin extends AbstractHostingAlertPlugin {
+  public static final String HOSTING_AI_ALERT = "io.holoinsight.plugin.DefaultHostingAlertPlugin";
+
+  @Override
+  protected boolean invalidTenant(AlarmRuleDTO alarmRuleDTO,
+      IntegrationPluginDTO disableIntegrationPlugin) {
+    return false;
+  }
+
+  @Override
+  protected String getProductType() {
+    return HOSTING_AI_ALERT;
+  }
+
+  @Override
+  public String getSourceType() {
+    return "hosting_default";
+  }
+
+  @Override
+  public Boolean disable(IntegrationPluginDTO integrationPlugin) {
+    return disableAlertHosting(integrationPlugin);
+  }
+}

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/HostingAlert.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/HostingAlert.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.biz.plugin.model;
+
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.home.dal.model.AlarmRule;
+import io.holoinsight.server.home.dal.model.dto.IntegrationPluginDTO;
+import io.holoinsight.server.home.dal.model.dto.IntegrationProductDTO;
+import io.holoinsight.server.home.facade.AlarmRuleDTO;
+import io.holoinsight.server.home.facade.Rule;
+import io.holoinsight.server.home.facade.TimeFilter;
+import io.holoinsight.server.home.facade.emuns.AlertLevel;
+import io.holoinsight.server.home.facade.emuns.BoolOperationEnum;
+import io.holoinsight.server.home.facade.emuns.CompareOperationEnum;
+import io.holoinsight.server.home.facade.emuns.FunctionEnum;
+import io.holoinsight.server.home.facade.emuns.TimeFilterEnum;
+import io.holoinsight.server.home.facade.trigger.CompareConfig;
+import io.holoinsight.server.home.facade.trigger.CompareParam;
+import io.holoinsight.server.home.facade.trigger.DataSource;
+import io.holoinsight.server.home.facade.trigger.Filter;
+import io.holoinsight.server.home.facade.trigger.RuleConfig;
+import io.holoinsight.server.home.facade.trigger.Trigger;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author masaimu
+ * @version 2023-02-17 13:56:00
+ */
+public class HostingAlert {
+  public String ruleId;
+  public String alertType;
+  public String alertMetric;
+  public String metricType;
+  public String alertMetricAlias;
+  public String alertScope;
+  public String alertTitle;
+  public String downsample;
+  public String aggregator;
+  public String functionType;
+  public String stepNum;
+  public String slidingWindowAggregator;
+  public String slidingWindowSize;
+  public List<String> groupBy;
+  public List<Filter> filters;
+  public RuleConfig ruleConfig;
+  public String tenant;
+  public List<CompareConfig> compareConfigs;
+
+  public static HostingAlert parseAlarmRuleVO(AlarmRule alarmRule) {
+    Rule rule = J.fromJson(alarmRule.getRule(), Rule.class);
+    HostingAlert vo = new HostingAlert();
+    vo.ruleId = String.valueOf(alarmRule.getId());
+    vo.alertType = alarmRule.getRuleType();
+    vo.alertMetric = getMetric(rule);
+    vo.alertScope = getScope(rule);
+    vo.alertTitle = alarmRule.getRuleName();
+    vo.tenant = alarmRule.getTenant();
+    return vo;
+  }
+
+  private static String getScope(Rule rule) {
+    if (CollectionUtils.isEmpty(rule.getTriggers())) {
+      return StringUtils.EMPTY;
+    }
+    Trigger trigger = rule.getTriggers().get(0);
+    if (CollectionUtils.isEmpty(trigger.getDatasources())) {
+      return StringUtils.EMPTY;
+    }
+    DataSource dataSource = trigger.getDatasources().get(0);
+    List<Filter> filters = dataSource.getFilters();
+    if (CollectionUtils.isEmpty(filters)) {
+      return StringUtils.EMPTY;
+    }
+    Map<String, String> map = new HashMap<>();
+    for (Filter filter : filters) {
+      map.put(filter.getName(), filter.getValue());
+    }
+    return J.toJson(map);
+  }
+
+  private static String getMetric(Rule rule) {
+    if (CollectionUtils.isEmpty(rule.getTriggers())) {
+      return StringUtils.EMPTY;
+    }
+    Trigger trigger = rule.getTriggers().get(0);
+    if (CollectionUtils.isEmpty(trigger.getDatasources())) {
+      return StringUtils.EMPTY;
+    }
+    DataSource dataSource = trigger.getDatasources().get(0);
+    return dataSource.getMetric();
+  }
+
+  public AlarmRuleDTO parseAlertRule(IntegrationProductDTO product, IntegrationPluginDTO pluginDTO,
+      List<Filter> filters, String sourceType) {
+    if (pluginDTO == null) {
+      return null;
+    }
+    AlarmRuleDTO alarmRuleDTO = new AlarmRuleDTO();
+    alarmRuleDTO.setRuleName(alertTitle);
+    alarmRuleDTO.setRuleType(alertType);
+    alarmRuleDTO.setCreator(pluginDTO.creator);
+    alarmRuleDTO.setAlarmLevel(AlertLevel.Medium.getCode());
+    alarmRuleDTO
+        .setRuleDescribe(pluginDTO.getProduct() + " " + getAlertTypeDesc(alertType) + " 告警托管");
+    alarmRuleDTO.setStatus((byte) 1);
+    alarmRuleDTO.setIsMerge((byte) 1);
+    alarmRuleDTO.setRecover((byte) 1);
+    alarmRuleDTO.setTenant(pluginDTO.tenant);
+    alarmRuleDTO.setRule(buildRule(product, filters));
+    alarmRuleDTO.setTimeFilter(buildTimeFilter());
+    alarmRuleDTO.setSourceType(sourceType);
+    alarmRuleDTO.setSourceId(pluginDTO.id);
+    alarmRuleDTO.setEnvType(pluginDTO.json);
+
+    return alarmRuleDTO;
+  }
+
+  private String getAlertTypeDesc(String alertType) {
+    String desc = "规则";
+    if ("ai".equalsIgnoreCase(alertType)) {
+      desc = "智能";
+    }
+    return desc;
+  }
+
+  private Map<String, Object> buildTimeFilter() {
+    TimeFilter timeFilter = new TimeFilter();
+    timeFilter.setModel(TimeFilterEnum.DAY.getDesc());
+    timeFilter.setFrom("00:00:00");
+    timeFilter.setTo("23:59:59");
+    timeFilter.setWeeks(Collections.emptyList());
+    return J.toMap(J.toJson(timeFilter));
+  }
+
+  private Map<String, Object> buildRule(IntegrationProductDTO product, List<Filter> filters) {
+    Rule alertRule = new Rule();
+    alertRule.setBoolOperation(BoolOperationEnum.AND);
+    alertRule.setTriggers(buildTriggers(product, filters));
+    return J.toMap(J.toJson(alertRule));
+  }
+
+  private List<Trigger> buildTriggers(IntegrationProductDTO product, List<Filter> filters) {
+    Trigger trigger = new Trigger();
+    trigger.setQuery("a");
+    trigger.setAggregator(slidingWindowAggregator);
+    trigger.setDownsample(
+        StringUtils.isEmpty(slidingWindowSize) ? 1 : Long.valueOf(slidingWindowSize));
+    trigger.setStepNum(StringUtils.isEmpty(stepNum) ? 1 : Integer.valueOf(stepNum));
+    trigger.setType(FunctionEnum.valueOf(functionType));
+    trigger.setTriggerContent(buildTriggerContent());
+    trigger.setDatasources(buildDatasources(filters));
+    trigger.setRuleConfig(this.ruleConfig);
+    trigger.setCompareConfigs(this.compareConfigs);
+    return Arrays.asList(trigger);
+  }
+
+  // sample: CPU使用率 最近5个周期平均值大于等于80 周期为一分钟
+  protected String buildTriggerContent() {
+    StringBuilder content = new StringBuilder();
+    if ("ai".equalsIgnoreCase(this.alertType)) {
+      content.append(this.alertMetricAlias) //
+          .append(this.functionType) //
+          .append("智能告警");
+    } else {
+      content.append(alertMetricAlias) //
+          .append("最近").append(stepNum) //
+          .append("个周期的").append(slidingWindowAggregator) //
+          .append("值").append(parseCompare(compareConfigs)) //
+          .append(", 周期为").append(slidingWindowSize) //
+          .append("分钟");
+    }
+    return content.toString();
+  }
+
+  private String parseCompare(List<CompareConfig> compareConfigs) {
+    if (CollectionUtils.isEmpty(compareConfigs)) {
+      return StringUtils.EMPTY;
+    }
+    List<String> result = new ArrayList<>();
+    for (CompareConfig compareConfig : compareConfigs) {
+      List<CompareParam> compareParams = compareConfig.getCompareParam();
+
+      List<String> contents = new ArrayList<>();
+      for (CompareParam param : compareParams) {
+        contents.add(getCompareDesc(param.getCmp()) + param.getCmpValue());
+      }
+      String condition = String.join(" and ", contents);
+      result.add("[" + condition + "]");
+    }
+    return String.join(" or ", result);
+  }
+
+  private String getCompareDesc(CompareOperationEnum cmp) {
+    switch (cmp) {
+      case EQ:
+        return "等于";
+      case GT:
+        return "大于";
+      case LT:
+        return "小于";
+      case GTE:
+        return "大于等于";
+      case LTE:
+        return "小于等于";
+      case NEQ:
+        return "不等于";
+      default:
+        return "";
+    }
+  }
+
+  private List<DataSource> buildDatasources(List<Filter> filters) {
+    DataSource dataSource = new DataSource();
+    dataSource.setMetricType(metricType);
+    dataSource.setMetric(alertMetric);
+    if (!CollectionUtils.isEmpty(groupBy)) {
+      dataSource.setGroupBy(groupBy);
+    }
+    dataSource.setAggregator(aggregator);
+    dataSource.setDownsample(downsample);
+    dataSource.setName("a");
+    dataSource.setFilters(buildFilter(filters));
+    return Arrays.asList(dataSource);
+  }
+
+  private List<Filter> buildFilter(List<Filter> filters) {
+    List<Filter> list = new ArrayList<>();
+    if (!CollectionUtils.isEmpty(filters)) {
+      list.addAll(filters);
+    }
+    if (!CollectionUtils.isEmpty(this.filters)) {
+      list.addAll(this.filters);
+    }
+    return list;
+  }
+}

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/HostingAlertList.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/HostingAlertList.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.biz.plugin.model;
+
+import io.holoinsight.server.home.dal.model.dto.IntegrationPluginDTO;
+import io.holoinsight.server.home.dal.model.dto.IntegrationProductDTO;
+import io.holoinsight.server.home.facade.AlarmRuleDTO;
+import io.holoinsight.server.home.facade.trigger.Filter;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author masaimu
+ * @version 2023-02-17 14:50:00
+ */
+public class HostingAlertList {
+
+  public List<HostingAlert> hostingAlertList;
+
+  public List<AlarmRuleDTO> parseAlertRule(IntegrationProductDTO product,
+      IntegrationPluginDTO pluginDTO, List<Filter> filters, String sourceType) {
+    if (CollectionUtils.isEmpty(hostingAlertList)) {
+      return Collections.emptyList();
+    }
+    List<AlarmRuleDTO> list = new ArrayList<>();
+    for (HostingAlert hostingAlert : this.hostingAlertList) {
+      AlarmRuleDTO alarmRuleDTO =
+          hostingAlert.parseAlertRule(product, pluginDTO, filters, sourceType);
+      if (alarmRuleDTO == null) {
+        continue;
+      }
+      list.add(alarmRuleDTO);
+    }
+    return list;
+  }
+}

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/IntegrationProductFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/IntegrationProductFacadeImpl.java
@@ -27,7 +27,6 @@ import io.holoinsight.server.common.J;
 import io.holoinsight.server.common.JsonResult;
 import io.holoinsight.server.query.grpc.QueryProto;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.util.CollectionUtils;
 
 import org.springframework.web.bind.annotation.GetMapping;

--- a/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/IntegrationPluginIT.java
+++ b/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/IntegrationPluginIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.test.it;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.home.biz.plugin.model.DefaultHostingAlertPlugin;
+import io.holoinsight.server.home.biz.plugin.model.HostingAlert;
+import io.holoinsight.server.home.biz.plugin.model.HostingAlertList;
+import io.holoinsight.server.home.dal.model.dto.IntegrationFormDTO;
+import io.holoinsight.server.home.dal.model.dto.IntegrationMetricsDTO;
+import io.holoinsight.server.home.dal.model.dto.IntegrationPluginDTO;
+import io.holoinsight.server.home.dal.model.dto.IntegrationPluginDTO.DataRange;
+import io.holoinsight.server.home.dal.model.dto.IntegrationProductDTO;
+import io.holoinsight.server.home.facade.AlarmRuleDTO;
+import io.holoinsight.server.home.facade.page.MonitorPageRequest;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author masaimu
+ * @version 2023-03-24 13:55:00
+ */
+public class IntegrationPluginIT extends BaseIT {
+
+  IntegrationProductDTO product;
+  IntegrationPluginDTO plugin;
+  Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").disableHtmlEscaping().create();
+
+  @Order(1)
+  @Test
+  public void test_integration_product_create() {
+
+    IntegrationProductDTO condition = buildProduct();
+    // Create product
+    Map<String, Object> data = given() //
+        .body(new JSONObject(condition)) //
+        .when() //
+        .post("/webapi/integration/product/create") //
+        .then() //
+        .body("success", IS_TRUE) //
+        .extract() //
+        .path("data"); //
+    product = gson.fromJson(gson.toJson(data), IntegrationProductDTO.class);
+  }
+
+  @Order(2)
+  @Test
+  public void test_integration_plugin_create() throws InterruptedException {
+
+    IntegrationPluginDTO condition = buildPlugin(product);
+    // Create plugin
+    Map<String, Object> data = given() //
+        .body(new JSONObject(condition)) //
+        .when() //
+        .post("/webapi/integration/plugin/create") //
+        .then() //
+        .body("success", IS_TRUE) //
+        .extract() //
+        .path("data"); //
+    plugin = gson.fromJson(gson.toJson(data), IntegrationPluginDTO.class);
+
+    await("Test alert history generation") //
+        .atMost(Duration.ofSeconds(10)) //
+        .untilAsserted(() -> {
+          AlarmRuleDTO alertCondition = new AlarmRuleDTO();
+          alertCondition.setSourceType(new DefaultHostingAlertPlugin().getSourceType());
+          MonitorPageRequest<AlarmRuleDTO> pageRequest = new MonitorPageRequest<>();
+          pageRequest.setTarget(alertCondition);
+          given() //
+              .body(new JSONObject(J.toMap(J.toJson(pageRequest)))).log().all() //
+              .when() //
+              .post("/webapi/alarmRule/pageQuery") //
+              .then().log().all() //
+              .body("success", IS_TRUE) //
+              .body("data.items.size()", gt(0));
+        });
+
+
+
+  }
+
+  private IntegrationPluginDTO buildPlugin(IntegrationProductDTO product) {
+    IntegrationPluginDTO plugin = new IntegrationPluginDTO();
+    plugin.setProduct(product.name);
+    plugin.setVersion(product.version);
+    plugin.setTenant("default");
+    plugin.setCreator(product.creator);
+    plugin.setType(product.type);
+    plugin.setJson("{}");
+    plugin.setName(String.join("_", "default", plugin.type, product.getVersion()));
+    plugin.setWorkspace("default");
+
+    plugin.setCollectRange(buildDataRange());
+    return plugin;
+  }
+
+  private Map<String, Object> buildDataRange() {
+    DataRange dataRange = new DataRange();
+    dataRange.getValuesMap().put("app", "holoinsight-server-example");
+    return J.toMap(J.toJson(dataRange));
+  }
+
+  private IntegrationProductDTO buildProduct() {
+    DefaultHostingAlertPlugin defaultHostingAlertPlugin = new DefaultHostingAlertPlugin();
+    defaultHostingAlertPlugin.setName(DefaultHostingAlertPlugin.HOSTING_AI_ALERT);
+    String simpleName = defaultHostingAlertPlugin.getSimplePluginName();
+
+    IntegrationProductDTO integrationProductDTO = new IntegrationProductDTO();
+    integrationProductDTO.setName(simpleName);
+    integrationProductDTO.setProfile("Default智能告警托管");
+    integrationProductDTO.setOverview(
+        "<p style=\\\"box-sizing: inherit;  border: 0px; font-size: 12px; margin-top: 0px; margin-bottom: 16px; outline: 0px; padding: 0px; vertical-align: initial; color: #FFFFFF; font-family: NotoSans, &quot;Lucida Grande&quot;, &quot;Lucida Sans Unicode&quot;, sans-serif; white-space: normal;\\\">\\n    开启智能告警托管:\\n</p>\\n<ul style=\\\"box-sizing: inherit;  border: 0px; font-size: 12px; margin-bottom: 16px; outline: 0px; padding: 0px 0px 0px 2em; vertical-align: initial; list-style-position: initial; list-style-image: initial; color: #FFFFFF; font-family: NotoSans, &quot;Lucida Grande&quot;, &quot;Lucida Sans Unicode&quot;, sans-serif; white-space: normal;\\\" class=\\\" list-paddingleft-2\\\">\\n    <li>\\n        <p>\\n            对告警进行布控.\\n        </p>\\n    </li>\\n</ul>");
+    integrationProductDTO.setConfiguration(buildConfiguration());
+    integrationProductDTO.setTemplate(new HashMap<>());
+    integrationProductDTO.setMetrics(new IntegrationMetricsDTO());
+    integrationProductDTO.setStatus(true);
+    integrationProductDTO.setType(DefaultHostingAlertPlugin.HOSTING_AI_ALERT);
+    integrationProductDTO.setForm(new IntegrationFormDTO());
+    integrationProductDTO.setVersion("1");
+    integrationProductDTO.setCreator("admin");
+    return integrationProductDTO;
+  }
+
+  private String buildConfiguration() {
+    HostingAlertList hostingAlertList = new HostingAlertList();
+    hostingAlertList.hostingAlertList = new ArrayList<>();
+    HostingAlert a = buildHostingAlert("system_cpu_util", "cpu util ");
+    HostingAlert b = buildHostingAlert("system_mem_util", "mem util ");
+    hostingAlertList.hostingAlertList.add(a);
+    hostingAlertList.hostingAlertList.add(b);
+    return J.toJson(hostingAlertList);
+  }
+
+  private HostingAlert buildHostingAlert(String metricName, String alias) {
+    HostingAlert hostingAlert = new HostingAlert();
+    hostingAlert.alertMetric = metricName;
+    hostingAlert.alertType = "ai";
+    hostingAlert.metricType = "app";
+    hostingAlert.alertMetricAlias = alias;
+    hostingAlert.alertTitle = "[托管]" + alias + "智能告警";
+    hostingAlert.downsample = "1m-avg";
+    hostingAlert.aggregator = "avg";
+    hostingAlert.groupBy = Arrays.asList("app");
+    hostingAlert.functionType = "ValueUp";
+    return hostingAlert;
+  }
+}

--- a/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/bootstrap/ITSets.java
+++ b/test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/bootstrap/ITSets.java
@@ -7,6 +7,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 
 import io.holoinsight.server.test.it.AlertCalculateIT;
 import io.holoinsight.server.test.it.AlertRuleIT;
+import io.holoinsight.server.test.it.IntegrationPluginIT;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 
@@ -39,6 +40,7 @@ public class ITSets {
         .selectors(selectClass(LogMonitoringIT.class)) //
         .selectors(selectClass(AlertRuleIT.class)) //
         .selectors(selectClass(AlertCalculateIT.class)) //
+        .selectors(selectClass(IntegrationPluginIT.class)) //
         .build(); //
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #276 

# Rationale for this change
 
Encapsulate multiple alarm rules configuration into an alarm hosting plugin, and install or remove it via the IntegrationPluginFacade interface. This approach is suitable for enterprise operation and maintenance scenarios, where alarm configurations can be unified and adjusted for all resources.

# What changes are included in this PR?

- `server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/AbstractHostingAlertPlugin.java` is the base class of the alarm plugin, which provides the common capabilities of the alarm plugin.
- `server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/model/DefaultHostingAlertPlugin.java`: is the default implementation of the alarm plugin.

# Are there any user-facing changes?

Users can install the alert plugin via `/webapi/integration/plugin/create`

# How does this change test

Unit test: `test/server-e2e-test/src/test/java/io/holoinsight/server/test/it/IntegrationPluginIT.java`
