### PR TITLE
feat(home): Feeding time series data to anomaly algorithm

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/compute/algorithm/ExtendConfig.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/compute/algorithm/ExtendConfig.java
@@ -23,6 +23,8 @@ public class ExtendConfig {
 
   private Map<String, Object> dataInfo;
 
+  private Map<String, Map<Long, Double>> trendData;
+
   public static ExtendConfig triggerConverter(DataResult dataResult,
       FunctionConfigAIParam functionConfigAIParam) {
     ExtendConfig extendConfig = new ExtendConfig();
@@ -30,6 +32,7 @@ public class ExtendConfig {
       // 组装算法查询数据入参
       Map<String, Object> dataInfo = new HashMap<>();
       Map<String, Object> datasource = new HashMap<>();
+      Map<String, Map<Long, Double>> trendData = new HashMap<>();
       List<DataSource> triggetDataSources = functionConfigAIParam.getTrigger().getDatasources();
       // 目前算法只有单数据源
       DataSource triggetDataSource = triggetDataSources.get(0);
@@ -56,6 +59,9 @@ public class ExtendConfig {
       dataInfo.put("tenant", functionConfigAIParam.getTenant());
       dataInfo.put("datasources", datasources);
       extendConfig.setDataInfo(dataInfo);
+
+      trendData.put(triggetDataSource.getMetric(), dataResult.getPoints());
+      extendConfig.setTrendData(trendData);
     }
     return extendConfig;
   }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/ValueDownAbnormalDetect.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/ValueDownAbnormalDetect.java
@@ -67,7 +67,7 @@ public class ValueDownAbnormalDetect implements FunctionLogic {
         .setExtendConfig(ExtendConfig.triggerConverter(dataResult, functionConfigAIParam));
     RuleConfig ruleConfig = functionConfigAIParam.getTrigger().getRuleConfig();
     if (ruleConfig == null) {
-      ruleConfig = RuleConfig.defaultDownConfig();
+      ruleConfig = RuleConfig.defaultDownConfig(dataResult.getMetric());
     }
     valueAlgorithmRequest.setRuleConfig(ruleConfig);
     // 设置算法接口名称

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/ValueUpAbnormalDetect.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/ValueUpAbnormalDetect.java
@@ -67,7 +67,7 @@ public class ValueUpAbnormalDetect implements FunctionLogic {
         .setExtendConfig(ExtendConfig.triggerConverter(dataResult, functionConfigAIParam));
     RuleConfig ruleConfig = functionConfigAIParam.getTrigger().getRuleConfig();
     if (ruleConfig == null) {
-      ruleConfig = RuleConfig.defaultUpConfig();
+      ruleConfig = RuleConfig.defaultUpConfig(dataResult.getMetric());
     }
     valueAlgorithmRequest.setRuleConfig(ruleConfig);
     // 设置算法接口名称

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/RuleConfig.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/RuleConfig.java
@@ -3,28 +3,32 @@
  */
 package io.holoinsight.server.home.facade.trigger;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @author masaimu
  * @version 2023-02-23 20:05:00
  */
-public class RuleConfig {
-  public Success success;
+public class RuleConfig extends HashMap<String, RuleConfig.Success> {
 
-  public static RuleConfig defaultUpConfig() {
+  public static RuleConfig defaultUpConfig(String fieldName) {
     RuleConfig config = new RuleConfig();
-    config.success = new Success();
-    config.success.customAmplitude = 0.8;
-    config.success.customDuration = 2;
-    config.success.customChangeRate = 0.2;
+    Success success = new Success();
+    success.customAmplitude = 0.8;
+    success.customDuration = 2;
+    success.customChangeRate = 0.2;
+    config.put(fieldName, success);
     return config;
   }
 
-  public static RuleConfig defaultDownConfig() {
+  public static RuleConfig defaultDownConfig(String fieldName) {
     RuleConfig config = new RuleConfig();
-    config.success = new Success();
-    config.success.customAmplitude = 0.05;
-    config.success.customDuration = 2;
-    config.success.customChangeRate = 0.5;
+    Success success = new Success();
+    success.customAmplitude = 0.05;
+    success.customDuration = 2;
+    success.customChangeRate = 0.5;
+    config.put(fieldName, success);
     return config;
   }
 

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/IntegrationPluginFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/IntegrationPluginFacadeImpl.java
@@ -4,6 +4,7 @@
 package io.holoinsight.server.home.web.controller;
 
 import io.holoinsight.server.home.common.util.StringUtil;
+import io.holoinsight.server.home.web.common.TokenUrls;
 import io.holoinsight.server.registry.model.integration.LocalIntegrationTask;
 import io.holoinsight.server.common.J;
 import io.holoinsight.server.common.JsonResult;
@@ -50,6 +51,7 @@ import java.util.stream.Collectors;
  */
 @RestController
 @RequestMapping("/webapi/integration/plugin")
+@TokenUrls("/webapi/integration/plugin")
 public class IntegrationPluginFacadeImpl extends BaseFacade {
 
   @Autowired


### PR DESCRIPTION
# Which issue does this PR close?

Closes #291 

# Rationale for this change
 
We can improve the performance of our anomaly detection mechanism in intelligent alerting by only feeding the time series data to the algorithm, and avoiding the algorithm from making additional queries to the data source. This way, the algorithm can focus on the detection of anomalies in the time series data without incurring the additional overhead of querying the data source.

# What changes are included in this PR?

- Feeding data to algorithm in `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/data/load/AIAlarmLoadData.java`
- Setting a threshold baseline for the algorithm's intervention can help reduce false positives, which can improve the performance of the intelligent alarm system. By establishing a threshold baseline, we can set a specific threshold for the algorithm to detect anomalies, so that only values above the threshold will trigger an alarm. `server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/RuleConfig.java`

# Are there any user-facing changes?

None.

# How does this change test

e2e test: `io.holoinsight.server.test.it.IntegrationPluginIT`
