### PR TITLE
fix: fix the topology exception of the endpoint

### DIFF
--- a/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/TopologyServiceImpl.java
+++ b/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/TopologyServiceImpl.java
@@ -94,42 +94,47 @@ public class TopologyServiceImpl implements TopologyService {
       String serviceInstance, String endpoint, long startTime, long endTime, int depth,
       Map<String, String> termParams) throws IOException {
     List<Call.DeepCall> calls = new ArrayList<>();
-    List<Call.DeepCall> sourceEndpointList = new ArrayList<>();
-    Call.DeepCall sourceEndpoint = new Call.DeepCall();
-    sourceEndpoint.setSourceServiceName(service);
+    List<Call.DeepCall> sourceCalls = new ArrayList<>();
+    Call.DeepCall sourceCall = new Call.DeepCall();
+    sourceCall.setSourceServiceName(service);
     if (serviceInstance != null) {
-      sourceEndpoint.setSourceName(serviceInstance);
+      sourceCall.setSourceName(serviceInstance);
     }
     if (endpoint != null) {
-      sourceEndpoint.setSourceName(endpoint);
+      sourceCall.setSourceName(endpoint);
     }
-    sourceEndpointList.add(sourceEndpoint);
+    sourceCalls.add(sourceCall);
 
-    List<Call.DeepCall> destEndpointList = new ArrayList<>();
-    Call.DeepCall destEndpoint = new Call.DeepCall();
-    destEndpoint.setDestServiceName(service);
-    destEndpoint.setDestName(serviceInstance);
-    destEndpointList.add(destEndpoint);
+    List<Call.DeepCall> destCalls = new ArrayList<>();
+    Call.DeepCall destCall = new Call.DeepCall();
+    destCall.setDestServiceName(service);
+    if (serviceInstance != null) {
+      destCall.setDestName(serviceInstance);
+    }
+    if (endpoint != null) {
+      destCall.setDestName(endpoint);
+    }
+    destCalls.add(destCall);
 
     for (int i = depth; i > 0; i--) {
-      List<Call.DeepCall> newSourceEndpointList = new ArrayList<>();
-      for (Call.DeepCall item : sourceEndpointList) {
-        newSourceEndpointList.addAll(callsLoader.loadCalls(tenant, item.getSourceServiceName(),
+      List<Call.DeepCall> newSourceCalls = new ArrayList<>();
+      for (Call.DeepCall item : sourceCalls) {
+        newSourceCalls.addAll(callsLoader.loadCalls(tenant, item.getSourceServiceName(),
             item.getSourceName(), startTime, endTime, Const.DEST, termParams));
       }
-      sourceEndpointList.clear();
-      sourceEndpointList.addAll(newSourceEndpointList);
+      sourceCalls.clear();
+      sourceCalls.addAll(newSourceCalls);
 
-      List<Call.DeepCall> newDestEndpointList = new ArrayList<>();
-      for (Call.DeepCall item : destEndpointList) {
-        newDestEndpointList.addAll(callsLoader.loadCalls(tenant, item.getDestServiceName(),
+      List<Call.DeepCall> newDestCalls = new ArrayList<>();
+      for (Call.DeepCall item : destCalls) {
+        newDestCalls.addAll(callsLoader.loadCalls(tenant, item.getDestServiceName(),
             item.getDestName(), startTime, endTime, Const.SOURCE, termParams));
       }
-      destEndpointList.clear();
-      destEndpointList.addAll(newDestEndpointList);
+      destCalls.clear();
+      destCalls.addAll(newDestCalls);
 
-      calls.addAll(newSourceEndpointList);
-      calls.addAll(newDestEndpointList);
+      calls.addAll(newSourceCalls);
+      calls.addAll(newDestCalls);
     }
     return calls;
   }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
To fix the bug brought by the previous pull request: incorrectly apply `serviceInstanceCalls` to the topology construction of the `endpoint`, resulting in an abnormal topology query.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
The call loading of `service instance` or `endpoint` is abstracted as an interface, and the caller of topology construction will pass in different implementations.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI and integration tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
