### PR TITLE
fix(home): fix pql notification

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskCompute.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskCompute.java
@@ -88,7 +88,7 @@ public class AlertTaskCompute implements AlarmTaskExecutor<ComputeTaskPackage> {
           if (inspectConfig == null) {
             continue;
           }
-          alarmNotifies.add(AlertNotify.eventInfoConver(eventInfo, inspectConfig));
+          alarmNotifies.add(AlertNotify.eventInfoConvert(eventInfo, inspectConfig));
         }
         alertEventService.handleEvent(alarmNotifies);
       }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/FunctionEnum.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/emuns/FunctionEnum.java
@@ -12,7 +12,7 @@ public enum FunctionEnum {
   Current("Current", "当前时间值", "RULE"), //
   PeriodRate("PeriodRate", "同环比比例", "RULE"), //
   PeriodValue("PeriodValue", "同环比差值", "RULE"), //
-  PeriodAbs("PeriodAbv", "同环比绝对值", "RULE"), //
+  PeriodAbs("PeriodAbs", "同环比绝对值", "RULE"), //
   Step("Step", "周期时间比较", "RULE"), //
   ValueUp("ValueUp", "值上涨", "AI"), //
   ValueDown("ValueDown", "值下跌", "AI");


### PR DESCRIPTION
# Which issue does this PR close?

Closes #302 

# Rationale for this change
 
Fix pql alert notification.

# What changes are included in this PR?

- Set `notifyDataInfoMap` to `NotifyDataInfos` for PQL alert in `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java`.
- Build `notifyDataInfoMap` for PQL alert rule in `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AbstractUniformInspectRunningRule.java`

# Are there any user-facing changes?

None.

# How does this change test

E2E test: `io.holoinsight.server.test.it.AlertRuleIT`
