### PR TITLE
fix: fix name mapping

### DIFF
--- a/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/specification/OtlpMappings.java
+++ b/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/specification/OtlpMappings.java
@@ -19,12 +19,16 @@ public class OtlpMappings {
 
   private static final BiMap<String, String> OTLP_SW_MAPPINGS = HashBiMap.create();
 
+  private static final String NAME = "name";
+
   static {
     OTLP_SW_MAPPINGS.put("tenant", "resource.tenant");
     OTLP_SW_MAPPINGS.put("serviceName", "resource.service.name");
     OTLP_SW_MAPPINGS.put("serviceInstanceName", "resource.service.instance.name");
-    OTLP_SW_MAPPINGS.put("endpointName", "name");
+    OTLP_SW_MAPPINGS.put("endpointName", NAME);
   }
+
+
 
   /**
    * null -> null <br>
@@ -34,12 +38,13 @@ public class OtlpMappings {
    * endpointName -> name <br>
    * attributes.* -> attributes.* <br>
    * resource.* -> resource.* <br>
+   * name -> name <br>
    * OTHERWISE: * -> attributes.*
    *
    * @param name
    * @return
    */
-  public static String toOltp(String name) {
+  public static String toOtlp(String name) {
     if (name == null) {
       return null;
     }
@@ -47,7 +52,8 @@ public class OtlpMappings {
       return OTLP_SW_MAPPINGS.get(name);
     }
     if (StringUtils.startsWith(name, Const.OTLP_ATTRIBUTES_PREFIX)
-        || StringUtils.startsWith(name, Const.OTLP_RESOURCE_PREFIX)) {
+        || StringUtils.startsWith(name, Const.OTLP_RESOURCE_PREFIX)
+        || StringUtils.equals(name, NAME)) {
       return name;
     }
     return Const.OTLP_ATTRIBUTES_PREFIX + name;

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanEsStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanEsStorage.java
@@ -109,7 +109,7 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
     if (CollectionUtils.isNotEmpty(tags)) {
       BoolQueryBuilder tagMatchQuery = new BoolQueryBuilder();
       tags.forEach(tag -> tagMatchQuery
-          .must(new TermQueryBuilder(OtlpMappings.toOltp(tag.getKey()), tag.getValue())));
+          .must(new TermQueryBuilder(SpanDO.attributes(tag.getKey()), tag.getValue())));
       boolQueryBuilder.must(tagMatchQuery);
     }
 

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/postcal/PostCalMetricStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/postcal/PostCalMetricStorage.java
@@ -44,7 +44,7 @@ public abstract class PostCalMetricStorage implements MetricStorage {
     Assert.notNull(metricDefine, String.format("metric not found: %s", metric));
     Map<String, Object> mergedConditions = new HashMap<>();
     if (conditions != null) {
-      conditions.forEach((k, v) -> mergedConditions.put(OtlpMappings.toOltp(k), v));
+      conditions.forEach((k, v) -> mergedConditions.put(OtlpMappings.toOtlp(k), v));
     }
     if (metricDefine.getConditions() != null) {
       mergedConditions.putAll(metricDefine.getConditions());
@@ -52,7 +52,7 @@ public abstract class PostCalMetricStorage implements MetricStorage {
 
     Set<String> mergedGroups = new HashSet<>();
     if (groups != null) {
-      groups.forEach(group -> mergedGroups.add(OtlpMappings.toOltp(group)));
+      groups.forEach(group -> mergedGroups.add(OtlpMappings.toOtlp(group)));
     }
     if (metricDefine.getGroups() != null) {
       mergedGroups.addAll(metricDefine.getGroups());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
This PR is to fix the mapping error of the `name` field that does not carry the prefix `resource.`.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- The mapping of the `name` field in OtlpMappings.java is handled separately.
- Fixed a typo in OtlpMappings.java.
- Tag keys are prefixed with SpanDO.attributes().

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI and integration tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
