### PR TITLE
fix(home): fix alert concurrency

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskCompute.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskCompute.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -55,13 +56,13 @@ public class AlertTaskCompute implements AlarmTaskExecutor<ComputeTaskPackage> {
   private AlarmDataSet alarmDataSet;
 
   @Resource
-  private AbstractUniformInspectRunningRule abstractUniformInspectRunningRule;
+  protected AbstractUniformInspectRunningRule abstractUniformInspectRunningRule;
 
   @Resource
   private AlertEventService alertEventService;
 
   @Resource
-  private AlarmHistoryMapper alertHistoryDOMapper;
+  protected AlarmHistoryMapper alertHistoryDOMapper;
 
   @Resource
   private CacheData cacheData;
@@ -81,7 +82,7 @@ public class AlertTaskCompute implements AlarmTaskExecutor<ComputeTaskPackage> {
         Map<String, InspectConfig> inspectConfigMap = cacheData.getUniqueIdMap();
         List<AlertNotify> alarmNotifies = new ArrayList<>();
         for (EventInfo eventInfo : eventLists) {
-          if (eventInfo == null || StringUtils.isEmpty(eventInfo.getUniqueId())) {
+          if (StringUtils.isEmpty(eventInfo.getUniqueId())) {
             continue;
           }
           InspectConfig inspectConfig = inspectConfigMap.get(eventInfo.getUniqueId());
@@ -114,8 +115,8 @@ public class AlertTaskCompute implements AlarmTaskExecutor<ComputeTaskPackage> {
     }
   }
 
-  private List<EventInfo> calculate(ComputeTaskPackage computeTaskPackage) {
-    List<EventInfo> eventLists = new ArrayList<>();
+  protected List<EventInfo> calculate(ComputeTaskPackage computeTaskPackage) {
+    List<EventInfo> eventLists = new CopyOnWriteArrayList<>();
 
     if (CollectionUtils.isEmpty(computeTaskPackage.getInspectConfigs())) {
       return Collections.emptyList();

--- a/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskComputeTest.java
+++ b/server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskComputeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.alert.service.calculate;
+
+import io.holoinsight.server.home.alert.model.compute.ComputeTaskPackage;
+import io.holoinsight.server.home.alert.model.event.EventInfo;
+import io.holoinsight.server.home.dal.mapper.AlarmHistoryMapper;
+import io.holoinsight.server.home.facade.InspectConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author masaimu
+ * @version 2023-04-04 17:35:00
+ */
+public class AlertTaskComputeTest {
+  AlertTaskCompute alertTaskCompute = new AlertTaskCompute();
+
+  @Before
+  public void setUp() throws Exception {
+    AlarmHistoryMapper alertHistoryDOMapper = Mockito.mock(AlarmHistoryMapper.class);
+    AbstractUniformInspectRunningRule abstractUniformInspectRunningRule =
+        Mockito.mock(AbstractUniformInspectRunningRule.class);
+    Mockito.when(abstractUniformInspectRunningRule.eval(Mockito.any())).thenReturn(new EventInfo());
+    alertTaskCompute.abstractUniformInspectRunningRule = abstractUniformInspectRunningRule;
+    alertTaskCompute.alertHistoryDOMapper = alertHistoryDOMapper;
+  }
+
+  @Test
+  public void testConcurrency() {
+    ComputeTaskPackage computeTaskPackage = new ComputeTaskPackage();
+    computeTaskPackage.setInspectConfigs(new ArrayList<>());
+    for (int i = 0; i < 100; i++) {
+      InspectConfig inspectConfig = new InspectConfig();
+      computeTaskPackage.inspectConfigs.add(inspectConfig);
+    }
+    AtomicInteger count = new AtomicInteger(0);
+    AtomicInteger errorCount = new AtomicInteger(0);
+    for (int j = 0; j < 1000; j++) {
+      try {
+        List<EventInfo> eventInfos = alertTaskCompute.calculate(computeTaskPackage);
+        for (EventInfo eventInfo : eventInfos) {
+          if (eventInfo == null) {
+            count.incrementAndGet();
+          }
+        }
+      } catch (Throwable t) {
+        errorCount.incrementAndGet();
+      }
+    }
+    assertEquals(0, count.get());
+    assertEquals(0, errorCount.get());
+  }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #317 

# Rationale for this change
 
Fix the issue of alarm loss caused by concurrent calculation.

# What changes are included in this PR?

- Replace ArrayList with CopyOnWriteArrayList to solve the issue of concurrent writes to the list in `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskCompute.java`

# Are there any user-facing changes?

None.

# How does this change test

Unit test: `server/home/home-alert/src/test/java/io/holoinsight/server/home/alert/service/calculate/AlertTaskComputeTest.java`
