### PR TITLE
refactor: copy front files from docker image

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,7 +44,7 @@ jobs:
       run: ./scripts/all-in-one/build.sh
     - name: Build server docker image
       run: |
-        NO_BUILD_APP=1 docker buildx build --load -t holoinsight/server:latest -f ./scripts/docker/Dockerfile .
+        nobuild=1 docker buildx build --load -t holoinsight/server:latest -f ./scripts/docker/Dockerfile .
         docker save -o holoinsight-server.tar holoinsight/server:latest
     - name: Upload server docker image
       uses: actions/upload-artifact@v3

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -22,8 +22,8 @@ EXPOSE 80
 COPY scripts/api /home/admin/api
 COPY scripts/docker/nginx.conf /etc/nginx/nginx.conf
 
-COPY scripts/docker/dist.zip /home/admin/dist.zip
-RUN unzip -d /home/admin/holoinsight-server-static/ /home/admin/dist.zip
+COPY --from=holoinsight/front:5 --chown=admin:admin /dist.zip /home/admin/dist.zip
+RUN unzip -d /home/admin/holoinsight-server-static/ /home/admin/dist.zip && rm /home/admin/dist.zip
 
 COPY --chown=admin:admin server/all-in-one/all-in-one-bootstrap/target/holoinsight-server.jar /home/admin/app.jar
 RUN echo `date` > /home/admin/build-time

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -8,7 +8,7 @@ project_root=`realpath $script_dir/../..`
 
 cd $project_root
 
-if [ -z "$NO_BUILD_APP" ]; then
+if [ "$nobuild"x != "1"x  ]; then
   ./scripts/all-in-one/build.sh
 fi
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Before, we put the front-end build result `dist.zip` in the code base. This is a very bad practice. Now we put the front-end build result in another docker image, and then copy it to the holoinsight image to avoid pollution code library.

# What changes are included in this PR?


# Are there any user-facing changes?


# How does this change test
Local test

