### PR TITLE
fix: fix db load metrics fail

### DIFF
--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/postcal/MetricsManager.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/postcal/MetricsManager.java
@@ -50,6 +50,10 @@ public class MetricsManager {
     return materializedMetrics;
   }
 
+  /**
+   * Metrics defined in the database have higher priority, which can override the content in
+   * metrics.json
+   */
   @Scheduled(initialDelay = 10000L, fixedDelay = 60000L)
   private void loadFromDB() {
     try {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Fix the startup exception caused by the cache construction being later than the APM metrics initialization.

# What changes are included in this PR?
Loading APM metrics from the database is handled by try-catch and modified to execute regularly.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI and integration tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
