### PR TITLE
feat: add collector into quick start

### DIFF
--- a/deploy/examples/k8s/base/collector.yaml
+++ b/deploy/examples/k8s/base/collector.yaml
@@ -1,0 +1,105 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: holoinsight-example
+  name: collector-config
+data:
+  config.yml: |
+    receivers:
+      holoinsight_skywalking:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:11800
+            auth:
+              authenticator: http_forwarder_auth
+        holoinsight_server:
+          http:
+            endpoint: gateway:8080
+    
+    exporters:
+      otlp:
+        endpoint: gateway:11800
+        tls:
+          insecure: true
+    
+    processors:
+      batch:
+    
+    extensions:
+      health_check:
+      pprof:
+      zpages:
+      http_forwarder_auth:
+        url: http://gateway:8080/internal/api/gateway/apikey/check
+    
+    service:
+      extensions: [pprof, health_check, http_forwarder_auth]
+      pipelines:
+        traces:
+          receivers: [holoinsight_skywalking]
+          exporters: [otlp]
+          processors: [batch]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: holoinsight-example
+  name: collector
+  labels:
+    app: collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: collector
+  strategy:
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 2
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: collector
+    spec:
+      containers:
+        - name: app
+          image: holoinsight/otelcontribcol:latest
+          ports:
+            - name: grpc
+              containerPort: 11800
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            tcpSocket:
+              port: 8888
+            failureThreshold: 3
+            periodSeconds: 20
+            initialDelaySeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: 8888
+            failureThreshold: 3
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          volumeMounts:
+            - name: collector-config
+              mountPath: /config/config.yml
+              subPath: config.yml
+      volumes:
+        - name: collector-config
+          configMap:
+            name: collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: holoinsight-example
+  name: service-collector
+spec:
+  ports:
+    - name: grpc-skywalking
+      port: 11800
+      protocol: TCP
+      targetPort: 11800
+  selector:
+    app: collector

--- a/deploy/examples/k8s/base/kustomization.yaml
+++ b/deploy/examples/k8s/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - mongo.yaml
 - ceresdb.yaml
 - server.yaml
+- collector.yaml
 - cadvisor.yaml
 - daemonagent.yaml
 - clusteragent.yaml

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -30,8 +30,4 @@ RUN echo `date` > /home/admin/build-time
 
 COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.11.0-java8 /skywalking/agent /home/admin/skywalking-agent
 
-ENV SW_AGENT_NAME holoinsight-server-example
-ENV SW_AGENT_AUTHENTICATION example
-ENV SW_AGENT_COLLECTOR_BACKEND_SERVICES collector:11800
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -28,4 +28,10 @@ RUN unzip -d /home/admin/holoinsight-server-static/ /home/admin/dist.zip && rm /
 COPY --chown=admin:admin server/all-in-one/all-in-one-bootstrap/target/holoinsight-server.jar /home/admin/app.jar
 RUN echo `date` > /home/admin/build-time
 
+COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.11.0-java8 /skywalking/agent /home/admin/skywalking-agent
+
+ENV SW_AGENT_NAME holoinsight-server-example
+ENV SW_AGENT_AUTHENTICATION example
+ENV SW_AGENT_COLLECTOR_BACKEND_SERVICES collector:11800
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/server/common/common-service/src/main/java/io/holoinsight/server/common/security/InternalWebApiInterceptor.java
+++ b/server/common/common-service/src/main/java/io/holoinsight/server/common/security/InternalWebApiInterceptor.java
@@ -28,7 +28,7 @@ import java.util.Set;
 public class InternalWebApiInterceptor implements HandlerInterceptor {
   static final Set<String> LOCALHOST = Sets.newHashSet("localhost", "127.0.0.1", "0:0:0:0:0:0:0:1");
   private static final Set<String> INTERNAL_WHITE_HOSTS =
-      Sets.newHashSet("gateway.holoinsight-gateway", "gateway.holoinsight-server", "server");
+      Sets.newHashSet("gateway.holoinsight-gateway", "gateway.holoinsight-server");
 
   @Autowired
   private HoloinsightSecurityProperties properties;

--- a/server/common/common-service/src/main/java/io/holoinsight/server/common/security/InternalWebApiInterceptor.java
+++ b/server/common/common-service/src/main/java/io/holoinsight/server/common/security/InternalWebApiInterceptor.java
@@ -3,23 +3,20 @@
  */
 package io.holoinsight.server.common.security;
 
-import java.io.IOException;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.google.common.collect.Sets;
 import io.holoinsight.server.common.NetUtils;
 import io.holoinsight.server.common.web.InternalWebApi;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-
-import com.google.common.collect.Sets;
 import org.springframework.web.util.UrlPathHelper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Set;
 
 /**
  * 该 interceptor 用于拦截通过 spring mvc 定义的处理器
@@ -31,7 +28,7 @@ import org.springframework.web.util.UrlPathHelper;
 public class InternalWebApiInterceptor implements HandlerInterceptor {
   static final Set<String> LOCALHOST = Sets.newHashSet("localhost", "127.0.0.1", "0:0:0:0:0:0:0:1");
   private static final Set<String> INTERNAL_WHITE_HOSTS =
-      Sets.newHashSet("gateway.holoinsight-gateway", "gateway.holoinsight-server");
+      Sets.newHashSet("gateway.holoinsight-gateway", "gateway.holoinsight-server", "server");
 
   @Autowired
   private HoloinsightSecurityProperties properties;

--- a/server/gateway/gateway-core/pom.xml
+++ b/server/gateway/gateway-core/pom.xml
@@ -88,7 +88,13 @@
 			<artifactId>extension-storage</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>io.holoinsight.server</groupId>
+            <artifactId>apm-receiver</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
 
 </project>

--- a/server/gateway/gateway-core/src/main/java/io/holoinsight/server/gateway/core/trace/GatewayTraceConfiguration.java
+++ b/server/gateway/gateway-core/src/main/java/io/holoinsight/server/gateway/core/trace/GatewayTraceConfiguration.java
@@ -4,15 +4,15 @@
 package io.holoinsight.server.gateway.core.trace;
 
 import io.holoinsight.server.common.springboot.ConditionalOnFeature;
+import io.holoinsight.server.common.springboot.HoloinsightProperties;
 import io.holoinsight.server.gateway.core.trace.config.GetAgentConfigurationService;
 import io.holoinsight.server.gateway.core.trace.controller.AgentConfigurationController;
+import io.holoinsight.server.gateway.core.trace.exporter.LocalTraceExporter;
 import io.holoinsight.server.gateway.core.trace.exporter.RelayTraceExporter;
 import io.holoinsight.server.gateway.core.trace.exporter.TraceExporter;
 import io.holoinsight.server.gateway.core.trace.receiver.opentelemetry.TraceServiceImpl;
 import io.holoinsight.server.gateway.core.trace.scheduler.AgentConfigurationScheduler;
-
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,8 +32,10 @@ public class GatewayTraceConfiguration {
    * </p>
    */
   @Bean
-  @ConditionalOnMissingBean
-  public TraceExporter traceExporter() {
+  public TraceExporter traceExporter(HoloinsightProperties hp) {
+    if (hp.getRoles().getActive().contains("apm")) {
+      return new LocalTraceExporter();
+    }
     return new RelayTraceExporter();
   }
 

--- a/server/gateway/gateway-core/src/main/java/io/holoinsight/server/gateway/core/trace/exporter/LocalTraceExporter.java
+++ b/server/gateway/gateway-core/src/main/java/io/holoinsight/server/gateway/core/trace/exporter/LocalTraceExporter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.gateway.core.trace.exporter;
+
+import io.grpc.stub.StreamObserver;
+import io.holoinsight.server.apm.receiver.trace.SpanHandler;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * When the gateway and apm are deployed together, the beans are used directly
+ * <p>
+ * created at 2022/11/30
+ *
+ * @author xiangfeng.xzc
+ */
+public class LocalTraceExporter implements TraceExporter {
+    @Autowired
+    private SpanHandler spanHandler;
+
+    @Override
+    public void export(ExportTraceServiceRequest request, StreamObserver<ExportTraceServiceResponse> o) {
+        spanHandler.handleResourceSpans(request.getResourceSpansList());
+        o.onNext(ExportTraceServiceResponse.getDefaultInstance());
+        o.onCompleted();
+    }
+}

--- a/server/gateway/gateway-core/src/main/java/io/holoinsight/server/gateway/core/trace/exporter/LocalTraceExporter.java
+++ b/server/gateway/gateway-core/src/main/java/io/holoinsight/server/gateway/core/trace/exporter/LocalTraceExporter.java
@@ -17,13 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author xiangfeng.xzc
  */
 public class LocalTraceExporter implements TraceExporter {
-    @Autowired
-    private SpanHandler spanHandler;
+  @Autowired
+  private SpanHandler spanHandler;
 
-    @Override
-    public void export(ExportTraceServiceRequest request, StreamObserver<ExportTraceServiceResponse> o) {
-        spanHandler.handleResourceSpans(request.getResourceSpansList());
-        o.onNext(ExportTraceServiceResponse.getDefaultInstance());
-        o.onCompleted();
-    }
+  @Override
+  public void export(ExportTraceServiceRequest request,
+      StreamObserver<ExportTraceServiceResponse> o) {
+    spanHandler.handleResourceSpans(request.getResourceSpansList());
+    o.onNext(ExportTraceServiceResponse.getDefaultInstance());
+    o.onCompleted();
+  }
 }

--- a/test/scenes/common/base.yaml
+++ b/test/scenes/common/base.yaml
@@ -68,6 +68,18 @@ services:
     - 80 # nginx
     - 8080 # tomcat
     - 8000 # java debug
+    - 11800 # trace
+  collector:
+    image: ${collector_image:-holoinsight/otelcontribcol:latest}
+    healthcheck:
+      test: [ "CMD", "timeout", "1", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/11800" ]
+      interval: 3s
+      retries: 300
+      timeout: 10s
+    ports:
+      - 11800 # skywalking
+    volumes:
+    - ./collector-config.yml:/config/config.yml
   agent-image:
     image: ${server_image:-holoinsight/agent:latest}
     entrypoint: [ "true" ]

--- a/test/scenes/common/base.yaml
+++ b/test/scenes/common/base.yaml
@@ -59,6 +59,9 @@ services:
     environment:
       JAVA_APP_OPTS: "-Xmx1024m -Xms1024m -Xmn512m"
       JAVA_DEBUG_OPTS: ${JAVA_DEBUG_OPTS:-}
+      SW_AGENT_NAME: holoinsight-server-example
+      SW_AGENT_AUTHENTICATION: example
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:11800
     healthcheck:
       test: [ "CMD", "bash", "/home/admin/bin/health.sh" ]
       interval: 3s

--- a/test/scenes/common/collector-config.yml
+++ b/test/scenes/common/collector-config.yml
@@ -1,0 +1,34 @@
+receivers:
+  holoinsight_skywalking:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:11800
+        auth:
+          authenticator: http_forwarder_auth
+    holoinsight_server:
+      http:
+        endpoint: server:8080
+
+exporters:
+  otlp:
+    endpoint: server:11800
+    tls:
+      insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+  zpages:
+  http_forwarder_auth:
+    url: http://server:8080/internal/api/gateway/apikey/check
+
+service:
+  extensions: [pprof, health_check, http_forwarder_auth]
+  pipelines:
+    traces:
+      receivers: [holoinsight_skywalking]
+      exporters: [otlp]
+      processors: [batch]

--- a/test/scenes/scene-default/application.yaml
+++ b/test/scenes/scene-default/application.yaml
@@ -10,7 +10,7 @@ spring:
 
 holoinsight:
   roles:
-    active: query,registry,gateway,home,meta
+    active: query,registry,gateway,home,meta,apm
   metric:
     storage:
       type: ceresdbx
@@ -23,3 +23,10 @@ holoinsight:
             port: 9090
   flyway:
     enabled: false
+  features:
+    active: trace
+  storage:
+    elasticsearch:
+      enable: true
+      hosts: es
+      port: 9200

--- a/test/scenes/scene-default/application.yaml
+++ b/test/scenes/scene-default/application.yaml
@@ -30,3 +30,5 @@ holoinsight:
       enable: true
       hosts: es
       port: 9200
+  security:
+    whiteHosts: server

--- a/test/scenes/scene-default/docker-compose.yaml
+++ b/test/scenes/scene-default/docker-compose.yaml
@@ -18,6 +18,10 @@ services:
     depends_on:
       ceresdb:
         condition: service_healthy
+  es:
+    extends:
+      file: ../common/base.yaml
+      service: es
   mysql-data-init:
     extends:
       file: ../common/base.yaml
@@ -40,6 +44,15 @@ services:
         condition: service_healthy
     volumes:
     - ./application.yaml:/home/admin/application.yaml
+  collector:
+    extends:
+      file: ../common/base.yaml
+      service: collector
+    depends_on:
+      es:
+        condition: service_healthy
+      server:
+        condition: service_healthy
   agent-image:
     image: ${agent_image:-holoinsight/agent:latest}
     entrypoint: [ "true" ]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #340

# Rationale for this change
 [holoinsight-collector](https://github.com/traas-stack/holoinsight-collector) is used to receive and forward trace data.
Holoinsight quick start example enables trace collection and storage capabilities.

# What changes are included in this PR?
- add skywalking into dockerfile
- add collector into quick start exmple
- example enables trace
- add LocalTraceExporter for trace
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
`./test/scenes/scene-default/up.sh`
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
