### PR TITLE
fix: fill metric names as datasource name if it is not blank

### DIFF
--- a/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/DefaultQueryServiceImpl.java
+++ b/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/DefaultQueryServiceImpl.java
@@ -729,7 +729,9 @@ public class DefaultQueryServiceImpl implements QueryService {
         }
         QueryProto.QueryResponse.Builder rspBuilder = QueryProto.QueryResponse.newBuilder();
         List<QueryProto.Result> results = calculate(metricDefine.getMaterializedExp(), resultMap,
-            metricDefine.getName(), resultMap.keySet());
+            StringUtils.isNotEmpty(datasource.getName()) ? datasource.getName()
+                : datasource.getMetric(),
+            resultMap.keySet());
         rspBuilder.addAllResults(results);
         if (StringUtils.isNotEmpty(datasource.getDownsample())
             && StringUtils.isNotEmpty(datasource.getFillPolicy())) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Use `datasource.name` as the metric name of the returned result when it is not blank.

# What changes are included in this PR?
Use `datasource.name` as the metric name of the returned result when it is not blank.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI and E2E tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
