### PR TITLE
feat(home): update response to filter authentication failure

### DIFF
--- a/server/common/common/src/main/java/io/holoinsight/server/common/JsonUtils.java
+++ b/server/common/common/src/main/java/io/holoinsight/server/common/JsonUtils.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
 
 /**
  * <p>
@@ -101,6 +102,14 @@ public class JsonUtils {
   public static <T> T fromJson(String str, Class<T> clazz, Class<?> view) {
     try {
       return OM.readerWithView(view).forType(clazz).readValue(str);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static void writeValue(Writer w, Object value) {
+    try {
+      OM.writeValue(w, value);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/MetaDictKey.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/MetaDictKey.java
@@ -12,6 +12,7 @@ public class MetaDictKey {
   public static final String ULA_CLOSE = "ula_close";
   public static final String ULA_HOST = "ula_host";
   public static final String IS_QUERY_TEST = "is_query_test";
+  public static final String TOKEN_URL_WRITE_LIST = "token_url_write_list";
   public static final String IS_APM_MATERIALIZED = "is_apm_materialized";
 
   public static final String AGENT_INSTALL_HOST = "agentInstallHost";
@@ -34,8 +35,6 @@ public class MetaDictKey {
   public static final String MNP_ANTLOG_ACCESS_ID = "mnp_antlog_id";
   public static final String MNP_ANTLOG_ACCESS_KEY = "mnp_antlog_key";
   public static final String MNP_ANTLOG_URL = "mnp_antlog_url";
-
-  public static final String MARKETPLACE_JIGUANG_HOST = "jiguang_host";
   public static final String SYSTEM_NOTICE = "system_notice";
 
   public static final String METERING_LOG_OPEN = "metering_log_open";

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/MetaDictType.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/MetaDictType.java
@@ -16,5 +16,4 @@ public class MetaDictType {
   public static final String MANAGE_TASK = "manage_task";
   public static final String TRACE_AGENT_CONFIG = "trace_agent_config";
   public static final String NOTIFICATION_CONFIG = "notification_config";
-  public static final String MARKETPLACE_CONFIG = "marketplace_config";
 }

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/MetaDictUtil.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/MetaDictUtil.java
@@ -10,7 +10,9 @@ import io.holoinsight.server.home.common.service.SpringContext;
 import io.holoinsight.server.home.common.util.scope.IdentityType;
 import io.holoinsight.server.common.dao.entity.MetaDataDictValue;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -102,11 +104,6 @@ public class MetaDictUtil {
     return MetaDictUtil.getStringValue(MetaDictType.GLOBAL_CONFIG, MetaDictKey.SYSTEM_NOTICE);
   }
 
-  public static String getJiGuangHost() {
-    return MetaDictUtil.getStringValue(MetaDictType.MARKETPLACE_CONFIG,
-        MetaDictKey.MARKETPLACE_JIGUANG_HOST);
-  }
-
 
   public static Boolean getUlaClose() {
 
@@ -132,6 +129,14 @@ public class MetaDictUtil {
   public static List<String /* 任务名 */> getIgnoreTasks() {
     return MetaDictUtil.getValue(MetaDictType.MANAGE_TASK, MetaDictKey.IGNORE_TASK_LIST,
         new TypeToken<List<String>>() {});
+  }
+
+  public static List<String> getTokenUrlWriteList() {
+    List<String> value = MetaDictUtil.getValue(MetaDictType.GLOBAL_CONFIG,
+        MetaDictKey.TOKEN_URL_WRITE_LIST, new TypeToken<List<String>>() {});
+    if (CollectionUtils.isEmpty(value))
+      return new ArrayList<>();
+    return value;
   }
 
   public static Boolean isLogMeteringOpen() {

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/common/ResponseUtil.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/common/ResponseUtil.java
@@ -4,7 +4,10 @@
 package io.holoinsight.server.home.web.common;
 
 import io.holoinsight.server.common.J;
+import io.holoinsight.server.common.JsonResult;
+import io.holoinsight.server.common.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -26,8 +29,15 @@ public class ResponseUtil {
       res.setContentType("application/json; charset=UTF-8");
       res.getWriter().write(r);
     } catch (IOException e) {
-      log.error("响应JSON数据出错", e);
+      log.error("json error", e);
     }
+  }
+
+  public static void authFailedResponse(HttpServletResponse resp, int status, String errorMsg)
+      throws IOException {
+    resp.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    resp.setStatus(status);
+    JsonUtils.writeValue(resp.getWriter(), JsonResult.createFailResult(errorMsg));
   }
 
 }

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/config/RestAuthUtil.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/config/RestAuthUtil.java
@@ -18,13 +18,12 @@ public class RestAuthUtil {
 
   public static RestAuthUtil singleton = new RestAuthUtil();
 
-  public static final Set<String> NO_AUTH_PATH =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("/webapi/sys/authurl",
-          "/webapi/sys/config", "/webapi/token/apply", "/webapi/sys/time", "/webapi/user/logout",
-          "/webapi/sys/checkservice", "/api/v1/prometheus/write")));
+  public static final Set<String> NO_AUTH_PATH = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList("/webapi/sys/config", "/webapi/token/apply", "/webapi/sys/time",
+          "/webapi/user/logout", "/webapi/sys/checkservice", "/api/v1/prometheus/write")));
 
   public static final Set<String> AUTH_PATH =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("/webapi", "/openapi/microapp")));
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("/webapi", "/openapi")));
 
   public static final List<String> NO_AUTH_PREFIX =
       Collections.unmodifiableList(Arrays.asList("/actuator", "/internal/api/"));

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/SysFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/SysFacadeImpl.java
@@ -70,20 +70,9 @@ public class SysFacadeImpl extends BaseFacade {
     sysMap.put("ula", ulaFacade.getCurrentULA().name());
     sysMap.put("site", this.environmentProperties.getDeploymentSite());
     sysMap.put("authApplyUrl", ulaFacade.getCurrentULA().authApplyUrl());
-    sysMap.put("jiguanghost", MetaDictUtil.getJiGuangHost());
     sysMap.put("systemNotice", MetaDictUtil.getSystemNotice());
     return JsonResult.createSuccessResult(sysMap);
   }
-
-  // internal api, no publish !!!
-  // @ResponseBody
-  // @GetMapping(value = "/properties")
-  // public JsonResult<Map<String, Object>> properties() {
-  //
-  // Map<String, Object> sysMap = new HashMap<>();
-  // sysMap.put("properties", PropertiesListenerConfig.getAllProperty());
-  // return JsonResult.createSuccessResult(sysMap);
-  // }
 
   @RequestMapping(value = "/debug/enable/{ukFlag}", method = RequestMethod.GET)
   @ResponseBody

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/UserFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/UserFacadeImpl.java
@@ -6,7 +6,6 @@ package io.holoinsight.server.home.web.controller;
 import io.holoinsight.server.common.J;
 import io.holoinsight.server.common.JsonResult;
 import io.holoinsight.server.home.biz.ula.ULAFacade;
-import io.holoinsight.server.home.biz.service.MarketplacePluginService;
 import io.holoinsight.server.home.common.util.Debugger;
 import io.holoinsight.server.home.common.util.ResultCodeEnum;
 import io.holoinsight.server.home.common.util.scope.AuthTarget;
@@ -53,9 +52,6 @@ public class UserFacadeImpl extends BaseFacade {
   @Autowired
   private ULAFacade ulaFacade;
 
-  @Autowired
-  private MarketplacePluginService marketplacePluginService;
-
   @ResponseBody
   // @MonitorScopeAuth(targetType = AuthTargetType.TENANT, needPower = PowerConstants.VIEW)
   @GetMapping(value = "/getCurrentUser")
@@ -78,10 +74,6 @@ public class UserFacadeImpl extends BaseFacade {
         resultObj.put("tPowers", ma.getTenantViewPowerList());
         resultObj.put("tenants", ulaFacade.getCurrentULA().getUserTenants(mu));
         resultObj.put("loginUrl", ulaFacade.getCurrentULA().getLoginUrl());
-
-        resultObj.put("marketplaces",
-            marketplacePluginService.queryByTenant(ms.tenant, ms.workspace));
-
         Debugger.print("UserFacadeImpl", "getCurrentUser: " + J.toJson(resultObj));
         JsonResult.createSuccessResult(result, resultObj);
       }

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step4AccessLogFilter.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/filter/Step4AccessLogFilter.java
@@ -4,6 +4,7 @@
 package io.holoinsight.server.home.web.filter;
 
 import io.holoinsight.server.home.common.util.scope.RequestContext;
+import io.holoinsight.server.home.web.common.ResponseUtil;
 import io.holoinsight.server.home.web.wrapper.CountServletResponseWrapper;
 import io.holoinsight.server.common.J;
 import io.holoinsight.server.common.JsonResult;
@@ -59,10 +60,7 @@ public class Step4AccessLogFilter implements Filter {
     try {
       filterChain.doFilter(req, responseWrapper);
     } catch (Exception e) {
-      JsonResult<Object> result = new JsonResult<>();
-      JsonResult.createFailResult(result, String.valueOf(HttpStatus.BAD_REQUEST.value()),
-          e.getMessage());
-      resp.sendError(HttpStatus.BAD_REQUEST.value(), J.toJson(result));
+      ResponseUtil.authFailedResponse(resp, HttpStatus.BAD_REQUEST.value(), e.getMessage());
       logger.error(e.getMessage(), e);
     }
     StringBuilder builder = new StringBuilder();

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/interceptor/MonitorScopeAuthInterceptor.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/interceptor/MonitorScopeAuthInterceptor.java
@@ -72,16 +72,13 @@ public class MonitorScopeAuthInterceptor implements MethodInterceptor {
       boolean pass = authCheckByType(checkAuthType, needPower, ma, ms, mu);
 
       if (!pass) {
-        JsonResult<String> resp = new JsonResult<String>();
-        resp.setSuccess(false);
-        resp.setMessage("monitor tenant auth not enough, need power: " + needPower);
         log.warn("monitor tenant auth not enough, need power: " + needPower + ", ma:" + J.toJson(ma)
             + ", mu:" + J.toJson(mu) + ",ms:" + J.toJson(ms));
-        resp.setResultCode(ResultCodeEnum.NO_AUTH.name());
-        return resp;
+        return JsonResult
+            .createFailResult("monitor tenant auth not enough, need power: " + needPower);
       }
     } catch (Exception e) {
-      log.error("auth failed", e);
+      log.error("auth failed, " + e.getMessage(), e);
       throw e;
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #369 

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. update response to filter authentication failure, the return result is in json format, use **_JsonResult.class_**.

_before request_
```
curl -i --location --request POST 'http://localhost:8080/webapi/v1/query' \
--header 'accessKey: example1' \
--header 'Content-Type: application/json' \
--data '{
    "datasources": [
        {
            "metric": "k8s_pod_cpu_util",
            "aggregator": "none",
            "groupBy": [
                
            ],
            "start": 1681375070000,
            "end": 1681378670000
        }
    ],
    "tenant": "default"
}'
```
_before response_
```
HTTP/1.1 401
Server: nginx/1.20.1
Date: Fri, 14 Apr 2023 08:54:30 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 112
Connection: keep-alive
{
    "timestamp": "2023-04-14 16:44:59",
    "status": 405,
    "error": "Method Not Allowed",
    "path": "/webapi/v1/query"
}
```

_after request_
```
curl -i --location --request POST 'http://localhost:8080/webapi/v1/query' \
--header 'accessKey: example1' \
--header 'Content-Type: application/json' \
--data '{
    "datasources": [
        {
            "metric": "k8s_pod_cpu_util",
            "aggregator": "none",
            "groupBy": [
                
            ],
            "start": 1681375070000,
            "end": 1681378670000
        }
    ],
    "tenant": "default"
}'
```

_after response_

```
HTTP/1.1 401
Server: nginx/1.20.1
Date: Fri, 14 Apr 2023 08:54:30 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 112
Connection: keep-alive
{
    "success": false,
    "message": "/webapi/v1/query, accessKey is not existed",
    "resultCode": null,
    "data": null
}
```

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
