### PR TITLE
fix(alert): fix alert lost

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertNotifyHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertNotifyHandler.java
@@ -34,14 +34,15 @@ public abstract class AlertNotifyHandler implements AlertHandlerExecutor {
     if (CollectionUtils.isEmpty(alertNotifies)) {
       LOGGER.info("alertNotifies is empty.");
     }
+    int count = 0;
     for (AlertNotify alertNotify : alertNotifies) {
       try {
         LOGGER.info("{} alert notify handle begin.", alertNotify.getTraceId());
         if (alertNotify.getIsRecover() != null && alertNotify.getIsRecover()) {
           LOGGER.info("{} alert notify is recover.", alertNotify.getTraceId());
-          return;
+          continue;
         }
-
+        count++;
         sendPlugin(alertNotify);
         FuseProtector.voteComplete(NORMAL_AlertNotifyHandler);
       } catch (Throwable e) {
@@ -51,6 +52,7 @@ public abstract class AlertNotifyHandler implements AlertHandlerExecutor {
         FuseProtector.voteNormalError(NORMAL_AlertNotifyHandler, e.getMessage());
       }
     }
+    LOGGER.info("alert_notification_notify_step size [{}]", count);
   }
 
   private void sendPlugin(AlertNotify alertNotify) {

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertSaveHistoryHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertSaveHistoryHandler.java
@@ -71,6 +71,7 @@ public class AlertSaveHistoryHandler implements AlertHandlerExecutor {
       makeAlertHistory(alertHistoryMap, alertNotifyHistory);
 
       makeAlertRecover(alertHistoryMap, alertNotifyRecover);
+      LOGGER.info("alert_notification_history_step size [{}]", alertNotifies.size());
     } catch (Exception e) {
       LOGGER.error(
           "[HoloinsightAlertInternalException][AlertSaveHistoryHandler][{}] fail to alert_history_save for {}",
@@ -161,6 +162,8 @@ public class AlertSaveHistoryHandler implements AlertHandlerExecutor {
     alarmHistoryDetail.setAlarmContent(AlarmContentGenerator.genPqlAlarmContent(
         alertNotify.getPqlRule().getPql(), alertNotify.getPqlRule().getDataResult()));
     alarmHistoryDetailDOMapper.insert(alarmHistoryDetail);
+    LOGGER.info("{} AlarmSaveHistoryDetail {} {} ", alertNotify.getTraceId(),
+        alertNotify.getUniqueId(), historyId);
     alertNotify.setAlarmHistoryId(alarmHistoryDetail.getHistoryId());
     alertNotify.setAlarmHistoryDetailId(alarmHistoryDetail.getId());
   }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/GetSubscriptionHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/GetSubscriptionHandler.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -150,9 +151,9 @@ public class GetSubscriptionHandler implements AlertHandlerExecutor {
 
           List<AlarmSubscribe> alertSubscribeList =
               alarmSubscribeDOMapper.selectList(alertSubscribeQueryWrapper);
-          LOGGER.info("{} GetSubscription SUCCESS {} ", alertNotify.getTraceId(),
-              G.get().toJson(alertSubscribeList));
-          if (alertSubscribeList != null) {
+          LOGGER.info("{} GetSubscription_SUCCESS {} {} ", alertNotify.getTraceId(),
+              alertNotify.getUniqueId(), G.get().toJson(alertSubscribeList));
+          if (!CollectionUtils.isEmpty(alertSubscribeList)) {
             Set<String> userIdList = new HashSet<>();
             Set<Long> dingDingGroupIdList = new HashSet<>();
             List<WebhookInfo> webhookInfos = new ArrayList<>();

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/event/AlertEventService.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/event/AlertEventService.java
@@ -45,6 +45,7 @@ public class AlertEventService {
         logger.warn("AlertEventHanderList pipeline is empty.");
         return;
       }
+
       for (AlertHandlerExecutor handler : pipeline) {
         // 当前处理器处理数据，并返回是否继续向下处理
         handler.handle(alarmNotifies);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #374 

# Rationale for this change
 
Using `continue` instead of `return`

# What changes are included in this PR?

- Using `continue` instead of `return` in `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertNotifyHandler.java`
- Add stat logs.

# Are there any user-facing changes?

None.

# How does this change test

E2E test.
