### PR TITLE
feat: update skywalking agent version

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM holoinsight/server-base:1.0.2
 
-COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.11.0-java8 /skywalking/agent /home/admin/skywalking-agent
+COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.15.0-java8 /skywalking/agent /home/admin/skywalking-agent
 
 COPY --from=holoinsight/front:11 --chown=admin:admin /dist.zip /home/admin/dist.zip
 RUN unzip -d /home/admin/holoinsight-server-static/ /home/admin/dist.zip && rm /home/admin/dist.zip

--- a/test/demo/demo-client/Dockerfile
+++ b/test/demo/demo-client/Dockerfile
@@ -1,6 +1,6 @@
 FROM holoinsight/server-base:1.0.2
 
-COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.11.0-java8 /skywalking/agent /home/admin/skywalking-agent
+COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.15.0-java8 /skywalking/agent /home/admin/skywalking-agent
 
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./target/demo-client.jar /home/admin/demo-client.jar

--- a/test/demo/demo-server/Dockerfile
+++ b/test/demo/demo-server/Dockerfile
@@ -1,6 +1,6 @@
 FROM holoinsight/server-base:1.0.2
 
-COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.11.0-java8 /skywalking/agent /home/admin/skywalking-agent
+COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.15.0-java8 /skywalking/agent /home/admin/skywalking-agent
 
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./target/demo-server.jar /home/admin/demo-server.jar


### PR DESCRIPTION
# Which issue does this PR close?

Closes #376

# Rationale for this change
 - demo grpc version: 1.42.2
 - demo skywalking agent version: 8.11.0
 - skywalking agent 8.11.0 grpc server interceptor is  `io.grpc.internal.AbstractServerImplBuilder.addService`
- However, the interception point （`io.grpc.internal.AbstractServerImplBuilder.addService`）of grpc 1.42.2 version has changed, resulting in no interception of the grpc server service. 
- skywalking8.15.0 fixes this problem [skywalking pr](https://github.com/apache/skywalking-java/pull/457)
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
update demo skywalking agent version to 8.15.0
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
