### PR TITLE
test: fix failed ITs

### DIFF
--- a/test/scenes/demo/docker-compose.yaml
+++ b/test/scenes/demo/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     extends:
       service: demo-client-base
     image: holoinsight/demo-client:1.0.0
+    pull_policy: always
 
   demo-server-base:
     extends:
@@ -48,6 +49,7 @@ services:
     extends:
       service: demo-server-base
     image: holoinsight/demo-server:1.0.0
+    pull_policy: always
 
   demo-redis:
     image: redis:5

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/LogMonitoring_1_log_IT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/LogMonitoring_1_log_IT.java
@@ -61,7 +61,6 @@ public class LogMonitoring_1_log_IT extends BaseIT {
   @Test
   public void test_wait_log_monitoring_metric1() {
     await("Test querying log monitoring metrics") //
-        .atMost(Duration.ofMinutes(10)) //
         .untilAsserted(() -> {
           long end = System.currentTimeMillis() / 60000 * 60000;
           long start = end - 60000;
@@ -106,7 +105,7 @@ public class LogMonitoring_1_log_IT extends BaseIT {
   @Test
   public void test_wait_log_monitoring_metric2() {
     await("Test querying log monitoring metrics") //
-        .atMost(Duration.ofMinutes(10)) //
+        .atMost(Duration.ofMinutes(1)) //
         .untilAsserted(() -> {
           long end = System.currentTimeMillis() / 60000 * 60000;
           long start = end - 60000;

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmCallLinkDetailIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmCallLinkDetailIT.java
@@ -100,7 +100,7 @@ public class ApmCallLinkDetailIT extends BaseIT {
               .body("parentSpanId", eq(demoServerSpanId)); //
 
           resp.rootPath("data.spans.find{ it.serviceCode == '%s' && it.endpointName == '%s' }", //
-              withArgs("demo-server", "Mysql/JDBI/Statement/executeQuery")) //
+              withArgs("demo-server", "Mysql/JDBC/Statement/executeQuery")) //
               .body("parentSpanId", eq(demoServerSpanId)); //
 
           resp.rootPath("data.spans.find{ it.serviceCode == '%s' && it.endpointName == '%s' }", //


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
After updating the skywalking java agent version of demo-client and demo-server, some trace details changed, which leading to failed ITs. This PR fixes these failed ITs.

![image](https://user-images.githubusercontent.com/8319940/233260968-a3dc4cfd-1d33-404a-9e6b-7cdae3518983.png)

old is `Mysql/JDBI/Statement/executeQuery`

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
1. use `pull_policy: always` option for demo-client and demo-server
2. fix failed IT
3. set test_wait_log_monitoring_metric1 atMost wait to '5min' which is enough for a '5s log monitor task'
4. set test_wait_log_monitoring_metric2 atMost wait to '2min', because it will be completed soon when test_wait_log_monitoring_metric1 is executed successfully.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
