### PR TITLE
test: treat all exceptions as retryable errors

### DIFF
--- a/test/server-e2e-test/src/main/java/extensions/org/awaitility/core/ConditionFactory/ConditionFactoryExtension.java
+++ b/test/server-e2e-test/src/main/java/extensions/org/awaitility/core/ConditionFactory/ConditionFactoryExtension.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package extensions.org.awaitility.core.ConditionFactory;
+
+import org.awaitility.core.ConditionFactory;
+import org.awaitility.core.ThrowingRunnable;
+
+import manifold.ext.rt.api.Extension;
+import manifold.ext.rt.api.This;
+
+/**
+ * <p>
+ * created at 2023/4/20
+ *
+ * @author xzchaoo
+ */
+@Extension
+public class ConditionFactoryExtension {
+  /**
+   * <p>
+   * This method treats all exceptions as retryable errors.
+   * <p>
+   * When use {@link ConditionFactory#untilAsserted(ThrowingRunnable)}, only {@link AssertionError}
+   * will be treated as expected errors and then retry tests. Other exceptions will lead to test
+   * failure.
+   * <p>
+   * But it is also very common to encounter the following exceptions when using `rest-assured`.
+   * These exceptions should be treated as expected errors too.
+   * <ul>
+   * <li>{@link NullPointerException}</li>
+   * <li>{@link org.apache.http.NoHttpResponseException}</li>
+   * </ul>
+   * 
+   * @param self
+   * @param run
+   */
+  public static void untilNoException(@This ConditionFactory self, ThrowingRunnable run) {
+    self.untilAsserted(() -> {
+      try {
+        run.run();
+      } catch (Exception e) {
+        throw new AssertionError("wraps non AssertionError exception", e);
+      }
+    });
+  }
+}

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AlertCalculateIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AlertCalculateIT.java
@@ -169,7 +169,7 @@ public class AlertCalculateIT extends BaseIT {
 
     await("Alert history generation") //
         .atMost(Duration.ofMinutes(10)) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           AlarmHistoryDTO condition = new AlarmHistoryDTO();
           condition.setUniqueId("rule_" + currentId);
           MonitorPageRequest<AlarmHistoryDTO> pageRequest = new MonitorPageRequest<>();

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AlertRuleIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AlertRuleIT.java
@@ -282,7 +282,7 @@ public class AlertRuleIT extends BaseIT {
     System.out.println(uniqueId);
     await("Test alert history generation") //
         .atMost(Duration.ofMinutes(10)) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           AlarmHistoryDTO condition = new AlarmHistoryDTO();
           condition.setUniqueId(uniqueId);
           MonitorPageRequest<AlarmHistoryDTO> pageRequest = new MonitorPageRequest<>();

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AppMonitoringIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AppMonitoringIT.java
@@ -25,7 +25,7 @@ public class AppMonitoringIT extends BaseIT {
   @Test
   void test_has_VM_meta() {
     await("Has VM Meta") //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           given() //
               .pathParam("tenant", tenant) //
               .when() //
@@ -42,7 +42,7 @@ public class AppMonitoringIT extends BaseIT {
   public void test_has_correct_displayMenu() {
     await() //
         .atMost(Duration.ofMinutes(10)) //
-        .untilAsserted(() -> { //
+        .untilNoException(() -> { //
           given() //
               .pathParam("app", "holoinsight-server-example") //
               .when() //
@@ -63,7 +63,7 @@ public class AppMonitoringIT extends BaseIT {
     // After docker-docker bootstrapped, it takes about 2~3 minutes to generate first CPU data.
     await("Has System Metrics") //
         .atMost(5, TimeUnit.MINUTES) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           for (String metric : new String[] {"system_cpu_util", //
               "system_cpu_user", //
               "system_cpu_sys", //

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/CeresdbPqlMonitoringIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/CeresdbPqlMonitoringIT.java
@@ -48,7 +48,7 @@ public class CeresdbPqlMonitoringIT extends BaseIT {
   public void test_wait_pql_monitoring_metric1() {
     await("Test querying pql monitoring metrics") //
         .atMost(Duration.ofMinutes(2)) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           long end = System.currentTimeMillis() / 60000 * 60000;
           long start = end - 60000;
           JSONObject params = json() //

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/IntegrationPluginIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/IntegrationPluginIT.java
@@ -23,7 +23,6 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,7 +75,7 @@ public class IntegrationPluginIT extends BaseIT {
 
     await("Test alert rule generation") //
         .atMost(Duration.ofSeconds(10)) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           AlarmRuleDTO alertCondition = new AlarmRuleDTO();
           alertCondition.setSourceType(new DefaultHostingAlertPlugin().getSourceType());
           MonitorPageRequest<AlarmRuleDTO> pageRequest = new MonitorPageRequest<>();

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/LogMonitoringIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/LogMonitoringIT.java
@@ -96,7 +96,7 @@ public class LogMonitoringIT extends BaseIT {
   public void test_wait_log_monitoring_metrics() {
     await("Test querying log monitoring metrics") //
         .atMost(Duration.ofMinutes(10)) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           long end = System.currentTimeMillis() / 60000 * 60000;
           long start = end - 60000 * 10;
 

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/LogMonitoring_1_log_IT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/LogMonitoring_1_log_IT.java
@@ -61,7 +61,7 @@ public class LogMonitoring_1_log_IT extends BaseIT {
   @Test
   public void test_wait_log_monitoring_metric1() {
     await("Test querying log monitoring metrics") //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           long end = System.currentTimeMillis() / 60000 * 60000;
           long start = end - 60000;
 
@@ -106,7 +106,7 @@ public class LogMonitoring_1_log_IT extends BaseIT {
   public void test_wait_log_monitoring_metric2() {
     await("Test querying log monitoring metrics") //
         .atMost(Duration.ofMinutes(1)) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           long end = System.currentTimeMillis() / 60000 * 60000;
           long start = end - 60000;
 

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/MetaVMIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/MetaVMIT.java
@@ -41,7 +41,7 @@ public class MetaVMIT extends BaseIT {
   @Order(1)
   public void test_has_VM_metadata() {
     await("Has VM metadata") //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           val extract = given() //
               .pathParam("tenant", tenant) //
               .body(json().put("_type", "VM")) //
@@ -68,7 +68,7 @@ public class MetaVMIT extends BaseIT {
   @Order(2)
   public void test_has_system_metrics() {
     await("Has system metrics") //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           long now = now();
 
           JSONObject body = json() //

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/MetricMonitoringIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/MetricMonitoringIT.java
@@ -22,7 +22,7 @@ public class MetricMonitoringIT extends BaseIT {
   @Test
   public void test_query_not_exists_metrics_monitoring() {
     await("test query not exist metric") //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           long end = System.currentTimeMillis() / 60000 * 60000;
           long start = end - 60000;
           String name = "test_query_not_exists_metrics_monitoring";
@@ -55,7 +55,7 @@ public class MetricMonitoringIT extends BaseIT {
   @Test
   public void test_query_tag_values_monitoring_item() {
     await("test query tag values") //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           JSONObject body = new JSONObject();
           body.put("metric", "system_mem_util");
           body.put("key", "app");

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/TaskIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/TaskIT.java
@@ -18,7 +18,7 @@ public class TaskIT extends BaseIT {
   public void test_task_scheduler() {
     await("Test task scheduler") //
         .atMost(Duration.ofMinutes(2)) //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           given() //
               .pathParam("taskId", TaskEnum.TASK_DEMO.getCode()) //
               .when() //

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmAppMetricStatIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmAppMetricStatIT.java
@@ -23,7 +23,7 @@ public class ApmAppMetricStatIT extends BaseIT {
   @Test
   public void test_serviceList() {
     await() //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
 
           long now = System.currentTimeMillis();
           JSONObject body = json() //

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmCallLinkDetailIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmCallLinkDetailIT.java
@@ -21,7 +21,7 @@ public class ApmCallLinkDetailIT extends BaseIT {
   @Test
   public void test_trace_detail() {
     await() //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           String endpoint = "Jedis/incr";
           long now = System.currentTimeMillis();
           JSONObject r = json() //

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmCallLinkIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmCallLinkIT.java
@@ -20,7 +20,7 @@ public class ApmCallLinkIT extends BaseIT {
   @Test
   public void test_trace_search_by_app() {
     await() //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           for (String app : Arrays.asList("demo-client", "demo-server",
               "holoinsight-server-example")) {
             long now = System.currentTimeMillis();
@@ -45,7 +45,7 @@ public class ApmCallLinkIT extends BaseIT {
   @Test
   public void test_trace_search_by_endpoint() {
     await() //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
           for (String endpoint : Arrays.asList("Jedis/incr", "GET:/demo-server")) {
             long now = System.currentTimeMillis();
             JSONObject r = json() //

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmTopologyIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/apm/ApmTopologyIT.java
@@ -18,7 +18,7 @@ public class ApmTopologyIT extends BaseIT {
   @Test
   public void test_topology() {
     await() //
-        .untilAsserted(() -> {
+        .untilNoException(() -> {
 
           long now = System.currentTimeMillis();
           JSONObject r = json() //


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change



When use `ConditionFactory#untilAsserted(ThrowingRunnable)`, only `AssertionError`
will be treated as expected errors and then retry tests. Other exceptions will lead to test
failure.

But it is also very common to encounter the following exceptions when using `rest-assured`.
These exceptions should be treated as expected errors too.
- NullPointerException
- org.apache.http.NoHttpResponseException

This PR add a method which treats all exceptions as retryable errors.


# What changes are included in this PR?
This PR add a method which treats all exceptions as retryable errors.


<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
