### PR TITLE
fix: disable SkyWalking gRPC plugin

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM holoinsight/server-base:1.0.2
 
 COPY --chown=admin:admin --from=apache/skywalking-java-agent:8.15.0-java8 /skywalking/agent /home/admin/skywalking-agent
+# Temporarily disable the grpc plugin, because it will cause our business code to throw exceptions.
+RUN rm /home/admin/skywalking-agent/plugins/apm-grpc-1.x-plugin-8.15.0.jar
 
 COPY --from=holoinsight/front:11 --chown=admin:admin /dist.zip /home/admin/dist.zip
 RUN unzip -d /home/admin/holoinsight-server-static/ /home/admin/dist.zip && rm /home/admin/dist.zip


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Currently we have some gRPC methods calling `onNext` and `onComplete` asynchronously in another thread.  

Without using SkyWalking java agent, everything is fine.
When using SkyWalking java agent, these methods fails because `onComplete` will throw an exception caused by SkyWalking internal.

I think this is because the async behavior of our gRPC service impl.
According to [this doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Application-toolkit-trace-cross-thread.md) we should manually pass the SkyWalking internal tracing context to new thread.

I will try the doc and fix the bug in another PR.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Disable skywalking grpc plugin

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
