### PR TITLE
feat(home): logmonitor adds translation capabilities

### DIFF
--- a/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/model/dto/conf/CustomPluginConf.java
+++ b/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/model/dto/conf/CustomPluginConf.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class CustomPluginConf implements Serializable {
   private static final long serialVersionUID = 7595849765231492514L;
 
+  public ExtraConfig extraConfig;
   /**
    * 日志路径
    */
@@ -65,4 +66,10 @@ public class CustomPluginConf implements Serializable {
     public String colType;
   }
 
+  @Data
+  public static class ExtraConfig {
+    public Integer keyCleanInterval = 0;
+
+    public Integer maxKeySize = 1000;
+  }
 }

--- a/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/model/dto/conf/Translate.java
+++ b/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/model/dto/conf/Translate.java
@@ -4,9 +4,13 @@
 package io.holoinsight.server.home.dal.model.dto.conf;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -20,6 +24,18 @@ public class Translate implements Serializable {
   /**
    * 转换函数
    */
-  public List<ColumnCalExpr> exprs;
+  public List<TranslateTransform> transforms;
+
+  @ToString
+  @Getter
+  @Setter
+  public static class TranslateTransform {
+
+    // contains/regexp/append/mapping/const
+    private String type;
+    private Map<String, String> mappings;
+    private String defaultValue;
+
+  }
 
 }

--- a/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/model/dto/conf/Translate.java
+++ b/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/model/dto/conf/Translate.java
@@ -22,7 +22,7 @@ public class Translate implements Serializable {
   private static final long serialVersionUID = 8300941265450477069L;
 
   /**
-   * 转换函数
+   * trans function
    */
   public List<TranslateTransform> transforms;
 

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
@@ -17,6 +17,7 @@ import io.holoinsight.server.registry.model.Elect.TransFormFilterAppend;
 import io.holoinsight.server.registry.model.Elect.TransFormFilterConst;
 import io.holoinsight.server.registry.model.Elect.TransFormFilterMapping;
 import io.holoinsight.server.registry.model.Elect.TransFormFilterRegexpReplace;
+import io.holoinsight.server.registry.model.Elect.TransFormFilterSubstring;
 import io.holoinsight.server.registry.model.Elect.TransFormFilterSwitch;
 import io.holoinsight.server.registry.model.Elect.TransFormFilterSwitchCase;
 import io.holoinsight.server.registry.model.Elect.Transform;
@@ -632,9 +633,27 @@ public class GaeaSqlTaskUtil {
 
       switch (transform.getType().toLowerCase()) {
         case "append":
+          if (StringUtils.isBlank(transform.getDefaultValue())) {
+            break;
+          }
           TransFormFilterAppend append = new TransFormFilterAppend();
           append.setValue(transform.getDefaultValue());
+          append.setAppendIfMissing(false);
           transFormFilter.setAppendV1(append);
+          break;
+        case "substring":
+          if (StringUtils.isBlank(transform.getDefaultValue())) {
+            break;
+          }
+          String[] array = StringUtils.split(transform.getDefaultValue(), ",");
+          if (array.length < 2) {
+            break;
+          }
+          TransFormFilterSubstring substring = new TransFormFilterSubstring();
+          substring.setBegin(Integer.parseInt(array[0]));
+          substring.setEnd(Integer.parseInt(array[1]));
+          substring.setEmptyIfError(true);
+          transFormFilter.setSubstringV1(substring);
           break;
         case "mapping":
           if (CollectionUtils.isEmpty(transform.getMappings())) {

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/common/GaeaSqlTaskUtil.java
@@ -8,11 +8,18 @@ import io.holoinsight.server.home.dal.model.dto.conf.*;
 import io.holoinsight.server.home.dal.model.dto.conf.CollectMetric.AfterFilter;
 import io.holoinsight.server.home.dal.model.dto.conf.CollectMetric.Metric;
 import io.holoinsight.server.home.dal.model.dto.conf.CustomPluginConf.SplitCol;
+import io.holoinsight.server.home.dal.model.dto.conf.Translate.TranslateTransform;
 import io.holoinsight.server.registry.model.Elect;
 import io.holoinsight.server.registry.model.Elect.RefIndex;
 import io.holoinsight.server.registry.model.Elect.RefName;
+import io.holoinsight.server.registry.model.Elect.TransFormFilter;
+import io.holoinsight.server.registry.model.Elect.TransFormFilterAppend;
+import io.holoinsight.server.registry.model.Elect.TransFormFilterConst;
+import io.holoinsight.server.registry.model.Elect.TransFormFilterMapping;
+import io.holoinsight.server.registry.model.Elect.TransFormFilterRegexpReplace;
+import io.holoinsight.server.registry.model.Elect.TransFormFilterSwitch;
+import io.holoinsight.server.registry.model.Elect.TransFormFilterSwitchCase;
 import io.holoinsight.server.registry.model.Elect.Transform;
-import io.holoinsight.server.registry.model.Elect.TransformItem;
 import io.holoinsight.server.registry.model.ExecuteRule;
 import io.holoinsight.server.registry.model.From;
 import io.holoinsight.server.registry.model.From.Log;
@@ -526,22 +533,9 @@ public class GaeaSqlTaskUtil {
           break;
       }
 
-      if (null != rule.translate) {
-        Translate translate = rule.translate;
-        List<ColumnCalExpr> exprs = translate.exprs;
-
+      if (null != rule.translate && !CollectionUtils.isEmpty(rule.translate.transforms)) {
         Transform transform = new Transform();
-        List<TransformItem> transformItems = new ArrayList<>();
-        if (!CollectionUtils.isEmpty(exprs)) {
-          exprs.forEach(expr -> {
-            TransformItem transformItem = new TransformItem();
-            transformItem.setArg(expr.getParams());
-            transformItem.setFunc(expr.getFunc());
-            transformItems.add(transformItem);
-          });
-        }
-
-        transform.setTransforms(transformItems);
+        transform.setFilters(convertTransFormFilters(rule.translate.transforms));
         elect.setTransform(transform);
       }
 
@@ -619,26 +613,103 @@ public class GaeaSqlTaskUtil {
       default:
         break;
     }
-    if (null != rule.translate) {
-      Translate translate = rule.translate;
-      List<ColumnCalExpr> exprs = translate.exprs;
+    if (null != rule.translate && !CollectionUtils.isEmpty(rule.translate.transforms)) {
       Transform transform = new Transform();
-      List<TransformItem> transformItems = new ArrayList<>();
-      if (!CollectionUtils.isEmpty(exprs)) {
-        exprs.forEach(expr -> {
-          TransformItem transformItem = new TransformItem();
-          transformItem.setArg(expr.getParams());
-          transformItem.setFunc(expr.getFunc());
-          transformItems.add(transformItem);
-        });
-      }
-      transform.setTransforms(transformItems);
+      transform.setFilters(convertTransFormFilters(rule.translate.transforms));
       elect.setTransform(transform);
     }
     if (StringUtils.isNotEmpty(rule.defaultValue)) {
       elect.setDefaultValue(rule.defaultValue);
     }
     return elect;
+  }
+
+  private static List<TransFormFilter> convertTransFormFilters(
+      List<TranslateTransform> transforms) {
+    List<TransFormFilter> filters = new ArrayList<>();
+    transforms.forEach(transform -> {
+      TransFormFilter transFormFilter = new TransFormFilter();
+
+      switch (transform.getType().toLowerCase()) {
+        case "append":
+          TransFormFilterAppend append = new TransFormFilterAppend();
+          append.setValue(transform.getDefaultValue());
+          transFormFilter.setAppendV1(append);
+          break;
+        case "mapping":
+          if (CollectionUtils.isEmpty(transform.getMappings())) {
+            break;
+          }
+          TransFormFilterMapping mapping = new TransFormFilterMapping();
+          mapping.setMappings(transform.getMappings());
+          mapping.setDefaultValue(transform.getDefaultValue());
+          transFormFilter.setMappingV1(mapping);
+          break;
+        case "const":
+          TransFormFilterConst aConst = new TransFormFilterConst();
+          aConst.setValue(transform.getDefaultValue());
+          transFormFilter.setConstV1(aConst);
+          break;
+        case "contains":
+        case "regexp":
+          if (CollectionUtils.isEmpty(transform.getMappings())) {
+            break;
+          }
+
+          if (transform.getMappings().size() == 1 && transform.getType().equalsIgnoreCase("regexp")
+              && StringUtils.isBlank(transform.getDefaultValue())) {
+            TransFormFilterRegexpReplace regexpReplace = new TransFormFilterRegexpReplace();
+            Map<String, String> mappings = transform.getMappings();
+            regexpReplace.setExpression(mappings.keySet().iterator().next());
+            regexpReplace.setReplacement(mappings.values().iterator().next());
+            transFormFilter.setRegexpReplaceV1(regexpReplace);
+            break;
+          }
+
+          TransFormFilterSwitch aSwitch = new TransFormFilterSwitch(); {
+          TransFormFilterConst defaultConst = new TransFormFilterConst();
+          defaultConst.setValue(transform.getDefaultValue());
+          TransFormFilter defaultFilter = new TransFormFilter();
+          defaultFilter.setConstV1(defaultConst);
+          aSwitch.setDefaultAction(defaultFilter);
+        }
+          List<TransFormFilterSwitchCase> switchCases = new ArrayList<>();
+
+          transform.getMappings().forEach((k, v) -> {
+            TransFormFilterSwitchCase switchCase = new TransFormFilterSwitchCase();
+            TransFormFilter filter = new TransFormFilter();
+
+            Where caseWhere = new Where();
+            if (transform.getType().equalsIgnoreCase("regexp")) {
+              Regexp regexp = new Regexp();
+              regexp.setExpression(k);
+              regexp.setCatchGroups(true);
+              caseWhere.setRegexp(regexp);
+              TransFormFilterRegexpReplace regexpReplace = new TransFormFilterRegexpReplace();
+              regexpReplace.setReplacement(v);
+              filter.setRegexpReplaceV1(regexpReplace);
+            } else if (transform.getType().equalsIgnoreCase("contains")) {
+              Contains contains = new Contains();
+              contains.setValue(k);
+              caseWhere.setContains(contains);
+              TransFormFilterConst vConst = new TransFormFilterConst();
+              vConst.setValue(v);
+              filter.setConstV1(vConst);
+            }
+
+            switchCase.setCaseWhere(caseWhere);
+            switchCase.setAction(filter);
+            switchCases.add(switchCase);
+          });
+
+          aSwitch.setCases(switchCases);
+          transFormFilter.setSwitchCaseV1(aSwitch);
+          break;
+      }
+
+      filters.add(transFormFilter);
+    });
+    return filters;
   }
 
   public static String convertTimeLayout(String time) {

--- a/server/registry/registry-model/src/main/java/io/holoinsight/server/registry/model/Elect.java
+++ b/server/registry/registry-model/src/main/java/io/holoinsight/server/registry/model/Elect.java
@@ -4,6 +4,7 @@
 package io.holoinsight.server.registry.model;
 
 import java.util.List;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -100,22 +101,66 @@ public class Elect {
   @Getter
   @Setter
   public static class Transform {
-    private List<TransformItem> transforms;
+    private List<TransFormFilter> filters;
   }
+
 
 
   @ToString
   @Getter
   @Setter
-  public static class TransformItem {
-    /**
-     * 转换函数名称, 可以参考现有lego
-     */
-    private String func;
-    /**
-     * arg的内容要根据func来解释
-     */
-    private String arg;
+  public static class TransFormFilter {
+
+    private TransFormFilterAppend appendV1;
+    private TransFormFilterMapping mappingV1;
+    private TransFormFilterConst constV1;
+    private TransFormFilterRegexpReplace regexpReplaceV1;
+    private TransFormFilterSwitch switchCaseV1;
   }
 
+  @ToString
+  @Getter
+  @Setter
+  public static class TransFormFilterAppend {
+    private String value;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class TransFormFilterMapping {
+    private Map<String, String> mappings;
+    private String defaultValue;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class TransFormFilterConst {
+    private String value;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class TransFormFilterRegexpReplace {
+    private String expression;
+    private String replacement;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class TransFormFilterSwitch {
+    private List<TransFormFilterSwitchCase> cases;
+    private TransFormFilter defaultAction;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class TransFormFilterSwitchCase {
+    private Where caseWhere;
+    private TransFormFilter action;
+  }
 }

--- a/server/registry/registry-model/src/main/java/io/holoinsight/server/registry/model/Elect.java
+++ b/server/registry/registry-model/src/main/java/io/holoinsight/server/registry/model/Elect.java
@@ -111,6 +111,7 @@ public class Elect {
   @Setter
   public static class TransFormFilter {
 
+    private TransFormFilterSubstring substringV1;
     private TransFormFilterAppend appendV1;
     private TransFormFilterMapping mappingV1;
     private TransFormFilterConst constV1;
@@ -123,6 +124,18 @@ public class Elect {
   @Setter
   public static class TransFormFilterAppend {
     private String value;
+
+    private Boolean appendIfMissing;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  public static class TransFormFilterSubstring {
+    private int begin;
+    private int end;
+
+    private Boolean emptyIfError;
   }
 
   @ToString

--- a/server/registry/registry-model/src/main/java/io/holoinsight/server/registry/model/Where.java
+++ b/server/registry/registry-model/src/main/java/io/holoinsight/server/registry/model/Where.java
@@ -77,6 +77,8 @@ public class Where {
      * 正则表达式
      */
     private String expression;
+
+    private Boolean catchGroups;
   }
 
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #407 

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. support translation capabilities of log monitoring
 
func list:
- substringV1
```
doc: Cut out the substring 
params: 

- begin: begin must be >=0 

- end: If end==-1, the match ends 

- emptyIfError: boolean Specifies whether to return an empty string if an error (such as an overstep) occurs during the partitioning process
```

- appendV1

```
doc: Appends content to a string 
params: 

- value: "additional content ", 
- appendIfMissing: boolean: Default false. If true, appended only when there is no $value at the end

```
- mappingV1
```
doc: Mapping, equivalent to map.getOrDefault(str, defaultValue) in Java 
params: 
- mappings: A map with map<string, string> 
- defaultValue: indicates the default value
```

- constV1
```
doc: Returns a constant 
params: 
- value: A constant, expressed as a string, that is automatically converted according to the final type (such as a numeric class)
```

- regexpReplaceV1

```
If the current value matches the given regular expression, the replacement is used as replacement

filters:
- regexpV1:
  	expression: "holo(.*)"
  	replacement: "Holo${1}X-${123456}"

input=holoinsight
output=HoloinsightX-${123456}
```

- switchCaseV1

```
Can realize if/else control flow, column value translation and other functions.

Realization condition judgment: 

filters:
- switchCaseV1:
  	cases:
  	- caseWhere:
  	    regexp:
  	      expression: "holo(.*)"
  	      catchGroups: true
      action:
        regexpReplaceV1:          
          replacement: "Holo${1}X"


Implementation mapping: 

filters:
- switchCaseV1:
  	cases: 
    - caseWhere: 
        eq: 
          value: "a"
      action:
      	const: "1"
    - caseWhere:
       eq:
         value: "b"
      action:
      	const: "2"
     - caseWhere: 
       eq:
         value: "c"
      action:
      	const: "3"
   defaultAction:
     const: "unknown"
```
# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
