### PR TITLE
fix: fix ceresdb end timestamp

### DIFF
--- a/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxMetricStorage.java
+++ b/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxMetricStorage.java
@@ -402,7 +402,7 @@ public class CeresdbxMetricStorage implements MetricStorage {
     if (!isNestedQuery) {
       long start = queryParam.getStart();
       long end = queryParam.getEnd();
-      whereSqlBuilder.append("timestamp >= ").append(start).append(" AND ").append(" timestamp < ")
+      whereSqlBuilder.append("timestamp >= ").append(start).append(" AND ").append(" timestamp <= ")
           .append(end);
     }
     List<QueryFilter> filters = queryParam.getFilters();
@@ -444,7 +444,7 @@ public class CeresdbxMetricStorage implements MetricStorage {
     if (StringUtils.isNotBlank(downsample) && StringUtils.isNotBlank(aggregator)
         && !StringUtils.equalsIgnoreCase(aggregator, "none")) {
       String downsampleSql = "(SELECT time_bucket(`%s`, '%s') as timestamp, %s,"
-          + " %s(value) as value FROM %s WHERE timestamp >= %s AND timestamp < %s group by time_bucket(`%s`, '%s'),%s)";
+          + " %s(value) as value FROM %s WHERE timestamp >= %s AND timestamp <= %s group by time_bucket(`%s`, '%s'),%s)";
       String interval = getInterval(downsample);
       if (StringUtils.isNotBlank(interval)) {
         String tagNames;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #397 

# Rationale for this change
The query time range for ceresdb should be [begin, end] instead of  [begin, end).

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
