### PR TITLE
feat(home): alert log analysis

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/common/TimeRangeUtil.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/common/TimeRangeUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.alert.common;
+
+import io.holoinsight.server.home.facade.emuns.PeriodType;
+import io.holoinsight.server.home.facade.trigger.DataSource;
+import io.holoinsight.server.home.facade.trigger.Trigger;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author masaimu
+ * @version 2023-04-25 14:34:00
+ */
+public class TimeRangeUtil {
+
+  public static long getStartTimestamp(long timestamp, DataSource dataSource, Trigger trigger) {
+    long time = 1L;
+    // Compatible format: 1m or 1m-avg
+    String downsample = dataSource.getDownsample();
+    if (StringUtils.isNotBlank(downsample)) {
+      time = parseTime(downsample);
+    }
+    return timestamp - (trigger.getStepNum() - 1) * time * PeriodType.MINUTE.intervalMillis()
+        - trigger.getDownsample() * PeriodType.MINUTE.intervalMillis();
+  }
+
+  public static long getEndTimestamp(long timestamp, DataSource dataSource) {
+    long time = 1L;
+    // Compatible format: 1m or 1m-avg
+    String downsample = dataSource.getDownsample();
+    if (StringUtils.isNotBlank(downsample)) {
+      time = parseTime(downsample);
+    }
+    return timestamp + time * PeriodType.MINUTE.intervalMillis();
+  }
+
+  public static long parseTime(String downsample) {
+    String timeStr = downsample;
+    if (timeStr.contains("-")) {
+      timeStr = timeStr.split("-", 2)[0];
+    }
+    return Long.parseLong(timeStr.substring(0, timeStr.length() - 1));
+  }
+}

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
@@ -38,53 +38,59 @@ public class AlertNotify {
 
   private String workspace;
 
-  private String uniqueId; // 告警id
+  private String uniqueId;
 
-  private String ruleName; // 告警名称
+  private String ruleName;
 
-  private Long alarmTime; // 告警时间
+  private Long alarmTime;
 
-  private String alarmLevel; // 告警级别
+  private String alarmLevel;
 
-  private Map<Trigger, List<NotifyDataInfo>> notifyDataInfos; // 数据信息
+  // data info
+  private Map<Trigger, List<NotifyDataInfo>> notifyDataInfos;
 
-  private List<String> msgList; // 告警消息
+  // alert msg
+  private List<String> msgList;
 
-  private int aggregationNum; // 聚合告警数
+  private int aggregationNum;
 
-  private Boolean isRecover; // 恢复通知
+  private Boolean isRecover;
 
-  private List<SubscriptionInfo> subscriptionInfos; // 订阅信息
+  private List<SubscriptionInfo> subscriptionInfos;
 
-  private List<UserInfo> userInfos; // 用户信息
+  private List<UserInfo> userInfos;
 
-  private Map<String/* notify type */, List<String>> userNotifyMap; // 用户信息和通知渠道
+  private Map<String/* notify type */, List<String>> userNotifyMap;
 
-  private List<WebhookInfo> dingdingUrl; // 钉钉群
+  private List<WebhookInfo> dingdingUrl;
 
-  private List<WebhookInfo> webhookInfos; // 告警相关webhook消息
+  private List<WebhookInfo> webhookInfos;
 
-  private NotifyConfig notifyConfig; // 通知增加的信息
+  private NotifyConfig notifyConfig;
 
-  private InspectConfig ruleConfig; // 告警规则配置
+  // alert rule config
+  private InspectConfig ruleConfig;
 
-  private PqlRule pqlRule; // pql告警规则+结果
+  private PqlRule pqlRule;
 
-  private Boolean isPql; // 是否属于pql告警通知
+  private Boolean isPql;
 
-  private String alarmTraceId; // 告警唯一id
+  private String alarmTraceId;
 
-  public Long alarmHistoryId; // 告警历史 id
+  public Long alarmHistoryId;
 
-  public Long alarmHistoryDetailId; // 告警历史明细 id
+  public Long alarmHistoryDetailId;
 
-  private Long duration; // 持续时间
+  private Long duration;
 
   private String alertServer;
 
-  private String envType; // 环境类型
+  private String envType;
 
-  private String sourceType; // 来源类型
+  private String sourceType;
+
+  // log analysis content
+  private List<String> logAnalysis;
 
   public static AlertNotify eventInfoConvert(EventInfo eventInfo, InspectConfig inspectConfig) {
     AlertNotify alertNotify = new AlertNotify();

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotifyRequest.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotifyRequest.java
@@ -19,11 +19,14 @@ import java.util.Map;
 @Data
 public class AlertNotifyRequest {
 
-  private Map<String/* notify type */, List<String>> userNotifyMap; // 用户信息和通知渠道
+  /**
+   * user info and notification channel
+   */
+  private Map<String/* notify type */, List<String>> userNotifyMap;
 
-  private List<WebhookInfo> dingdingUrls; // 钉钉群
+  private List<WebhookInfo> dingdingUrls;
 
-  private List<WebhookInfo> webhookInfos; // 告警相关webhook消息
+  private List<WebhookInfo> webhookInfos;
 
   private String traceId;
 
@@ -31,34 +34,37 @@ public class AlertNotifyRequest {
 
   private String workspace;
 
-  private String uniqueId; // 告警规则+id
+  private String uniqueId;
 
-  private String ruleId; // 告警id
+  private String ruleId;
 
-  private String ruleName; // 告警名称
+  private String ruleName;
 
-  private Long alarmTime; // 告警时间
+  private Long alarmTime;
 
-  private String alarmLevel; // 告警级别
+  private String alarmLevel;
 
-  private String aggregationNum; // 聚合告警数
+  private String aggregationNum;
 
-  private Map<Trigger, List<NotifyDataInfo>> notifyDataInfos; // 告警计算结果
+  private Map<Trigger, List<NotifyDataInfo>> notifyDataInfos;
 
-  private InspectConfig ruleConfig; // 告警规则配置
+  private InspectConfig ruleConfig;
 
-  private String envType; // 环境类型
+  private String envType;
 
-  private AlertRuleExtra alertRuleExtra; // 告警附加信息
+  private AlertRuleExtra alertRuleExtra;
 
-  public Long alarmHistoryId; // 告警历史 id
+  public Long alarmHistoryId;
 
-  public Long alarmHistoryDetailId; // 告警历史明细 id
+  public Long alarmHistoryDetailId;
 
-  public String sourceType; // 来源类型
+  public String sourceType;
 
-  private Long duration; // 持续时间
+  private Long duration;
 
-  private String alertServer; // 告警机器
+  private String alertServer;
+
+  // log analysis content
+  private List<String> logAnalysis;
 
 }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertNotifyHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertNotifyHandler.java
@@ -78,6 +78,7 @@ public abstract class AlertNotifyHandler implements AlertHandlerExecutor {
 
     alertNotifyRequest.setTenant(getTenant(alertNotify));
     alertNotifyRequest.setWorkspace(getWorkspace(alertNotify));
+    alertNotifyRequest.setLogAnalysis(alertNotify.getLogAnalysis());
 
     if (!CollectionUtils.isEmpty(alertNotify.getNotifyDataInfos())) {
       alertNotifyRequest.setNotifyDataInfos(alertNotify.getNotifyDataInfos());

--- a/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/converter/AlarmHistoryDetailConverter.java
+++ b/server/home/home-dal/src/main/java/io/holoinsight/server/home/dal/converter/AlarmHistoryDetailConverter.java
@@ -3,16 +3,19 @@
  */
 package io.holoinsight.server.home.dal.converter;
 
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.common.dao.transformer.ListJsonMapper;
 import io.holoinsight.server.home.dal.model.AlarmHistoryDetail;
 import io.holoinsight.server.home.facade.AlarmHistoryDetailDTO;
-import io.holoinsight.server.common.dao.transformer.ListJsonMapper;
+import io.holoinsight.server.home.facade.trigger.AlertHistoryDetailExtra;
+import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 
 import java.util.List;
 
 /**
  * @author wangsiyuan
- * @date 2022/4/12 9:40 下午
+ * @date 2022/4/12 21:40
  */
 @Mapper(componentModel = "spring", uses = {ListJsonMapper.class})
 public interface AlarmHistoryDetailConverter {
@@ -22,4 +25,18 @@ public interface AlarmHistoryDetailConverter {
   AlarmHistoryDetail dtoToDO(AlarmHistoryDetailDTO alarmHistoryDetailDTO);
 
   List<AlarmHistoryDetailDTO> dosToDTOs(Iterable<AlarmHistoryDetail> alarmHistoryDetails);
+
+  default String map(AlertHistoryDetailExtra value) {
+    if (value == null) {
+      return null;
+    }
+    return J.toJson(value);
+  }
+
+  default AlertHistoryDetailExtra map(String value) {
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    return J.fromJson(value, AlertHistoryDetailExtra.class);
+  }
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlarmHistoryDetailDTO.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlarmHistoryDetailDTO.java
@@ -3,13 +3,14 @@
  */
 package io.holoinsight.server.home.facade;
 
+import io.holoinsight.server.home.facade.trigger.AlertHistoryDetailExtra;
 import lombok.Data;
 
 import java.util.Date;
 
 /**
  * @author wangsiyuan
- * @date 2022/6/9 9:32 下午
+ * @date 2022/6/9 21:32
  */
 @Data
 public class AlarmHistoryDetailDTO {
@@ -18,24 +19,12 @@ public class AlarmHistoryDetailDTO {
    */
   private Long id;
 
-  /**
-   * 告警时间
-   */
   private Date alarmTime;
 
-  /**
-   * 告警id
-   */
   private String uniqueId;
 
-  /**
-   * 告警历史id
-   */
   private Long historyId;
 
-  /**
-   * 租户id
-   */
   private String tenant;
 
   /**
@@ -43,28 +32,15 @@ public class AlarmHistoryDetailDTO {
    */
   private String workspace;
 
-  /**
-   * 触发方式简述
-   */
   private String alarmContent;
 
-  /**
-   * 数据源信息
-   */
   private String datasource;
 
-  /**
-   * 来源类型
-   */
   private String sourceType;
 
-  /**
-   * 来源id
-   */
   private Long sourceId;
 
-  /**
-   * 环境类型
-   */
   private String envType;
+
+  private AlertHistoryDetailExtra extra;
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlertTemplateField.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/AlertTemplateField.java
@@ -42,7 +42,7 @@ public enum AlertTemplateField {
   aggregationNum("aggregationNum", "告警聚合数量", "numeric"), //
   ALERT_TRIGGER_CONDITION("ALERT_TRIGGER_CONDITION", "告警触发条件", "string"), //
   SOURCE_TYPE("SOURCE_TYPE", "告警来源类型", "string"), //
-
+  LOG_CONTENT("LOG_CONTENT", "告警来源日志采样内容", "string"), //
 
   ;
 

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/InspectConfig.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/InspectConfig.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 /**
  * @author wangsiyuan
- * @date 2022/3/11 6:45 下午
+ * @date 2022/3/11 18:45
  */
 @Data
 public class InspectConfig {
@@ -25,29 +25,35 @@ public class InspectConfig {
 
   private String ruleType;
 
-  private String alarmLevel; // 枚举
+  private String alarmLevel;
 
   private String ruleDescribe;
 
   private Rule rule;
 
-  private PqlRule pqlRule; // pql规则+数据
+  // pql rule and data
+  private PqlRule pqlRule;
 
   private Boolean isPql;
 
-  private TimeFilter timeFilter; // 生效时间
+  private TimeFilter timeFilter;
 
-  private Boolean status; // 开启报警
+  // alert status
+  private Boolean status;
 
-  private Boolean isMerge; // 开启合并
+  private Boolean isMerge;
 
-  private String mergeType; // 合并方式
+  private String mergeType;
 
-  private Boolean recover; // 恢复通知
+  private Boolean recover;
 
-  private String noticeType; // 枚举，通知方式
+  private String noticeType;
 
-  private String envType; // 环境类型
+  private String envType;
 
-  private String sourceType; // 来源类型
+  private String sourceType;
+
+  private Long sourceId;
+
+  private boolean logPatternEnable;
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/NotificationTemplate.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/NotificationTemplate.java
@@ -170,6 +170,8 @@ public class NotificationTemplate {
         return templateValue.aggregationNum;
       case ALERT_TRIGGER_CONDITION:
         return templateValue.triggerCondition;
+      case LOG_CONTENT:
+        return templateValue.logContent;
     }
     return StringUtils.EMPTY;
   }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/TemplateValue.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/TemplateValue.java
@@ -8,67 +8,75 @@ import io.holoinsight.server.home.facade.emuns.AlertLevel;
 import io.holoinsight.server.home.facade.trigger.DataSource;
 import io.holoinsight.server.home.facade.trigger.Trigger;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author wangsiyuan
- * @date 2022/3/29 8:10 下午
+ * @date 2022/3/29 20:10
  */
 @Data
 public class TemplateValue {
 
-  String tenant; // 租户
+  String tenant;
 
-  String workspace; // workspace
+  String workspace;
 
-  String ruleId; // 规则id
+  String ruleId;
 
-  String uniqueId; // 唯一id
+  String uniqueId;
 
-  String ruleName; // 规则名称
+  String ruleName;
 
-  String alarmTime; // 告警时间
+  String alarmTime;
 
-  String alarmStartTime; // 告警开始时间
+  String alarmStartTime;
 
-  String alarmTimestamp; // 告警时间戳
+  String alarmTimestamp;
 
-  String metric; // 监控项
+  String metric;
 
-  AlertLevel alarmLevel; // 告警级别
+  AlertLevel alarmLevel;
 
-  String alarmTags; // 告警对象
+  String alarmTags;
 
-  String alarmContent; // 告警内容
+  String alarmContent;
 
-  String aggregationNum; // 聚合告警数
+  String aggregationNum;
 
-  String ruleUrl; // 告警url
+  String ruleUrl;
 
-  InspectConfig ruleConfig; // 告警配置规则
+  InspectConfig ruleConfig;
 
-  String alarmTraceId; // 告警唯一id
+  String alarmTraceId;
 
-  Long alarmHistoryId; // 告警历史 id
+  Long alarmHistoryId;
 
-  Long alarmHistoryDetailId; // 告警历史明细 id
+  Long alarmHistoryDetailId;
 
-  Double alertValue; // 告警触发值
+  Double alertValue;
 
-  String sourceType; // 来源类型
+  String sourceType;
 
-  String alertQuery; // 告警查询
+  String alertQuery;
 
-  String metricType; // 指标类型
+  String metricType;
 
-  Long duration; // 持续时间
+  Long duration;
 
-  String triggerCondition; // 触发条件
+  String triggerCondition;
 
-  String alertServer; // 告警机器
+  String alertServer;
+
+  /**
+   * log content triggered alert
+   */
+  String logContent;
 
   public void setAlertQuery(Trigger trigger) {
     StringBuilder query = new StringBuilder();
@@ -116,5 +124,19 @@ public class TemplateValue {
 
   public void setMetric(String pql) {
     this.metric = pql;
+  }
+
+  public void setLogContent(List<String> logAnalysis) {
+    if (CollectionUtils.isEmpty(logAnalysis)) {
+      this.logContent = StringUtils.EMPTY;
+    } else {
+      String json = logAnalysis.get(0);
+      Map<String, Object> map = J.toMap(json);
+      String sample = (String) map.getOrDefault("sample", "");
+      Map<String, Object> ipCountMap =
+          (Map<String, Object>) map.getOrDefault("ipCountMap", new HashMap<>());
+      sample = sample + " FROM [" + String.join(",", ipCountMap.keySet()) + "]";
+      this.logContent = sample;
+    }
   }
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/AlertHistoryDetailExtra.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/AlertHistoryDetailExtra.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.facade.trigger;
+
+import java.util.List;
+
+/**
+ * @author masaimu
+ * @version 2023-04-25 16:26:00
+ */
+public class AlertHistoryDetailExtra {
+  public List<String> logAnalysisContent;
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #411 

# Rationale for this change
 
Alert supports including log samples in alert history and notification.

# What changes are included in this PR?

- Alert handler will try to query log sample in `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertSaveHistoryHandler.java` if the log analysis is enable in the logmonitor datasource.

# Are there any user-facing changes?

If the `LOG_CONTENT` is included in the DingTalk alarm template, the alarm message will carry the log sampling content.

# How does this change test

Supplement later.
