### PR TITLE
feat(home): alert history detail query

### DIFF
--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/AlarmHistoryDetailService.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/AlarmHistoryDetailService.java
@@ -9,6 +9,9 @@ import io.holoinsight.server.home.facade.page.MonitorPageRequest;
 import io.holoinsight.server.home.facade.page.MonitorPageResult;
 import com.baomidou.mybatisplus.extension.service.IService;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author wangsiyuan
  * @date 2022/6/9 9:38 下午
@@ -18,5 +21,7 @@ public interface AlarmHistoryDetailService extends IService<AlarmHistoryDetail> 
 
   MonitorPageResult<AlarmHistoryDetailDTO> getListByPage(
       MonitorPageRequest<AlarmHistoryDetailDTO> pageRequest);
+
+  List<Map<String, Object>> count(MonitorPageRequest<AlarmHistoryDetailDTO> pageRequest);
 
 }

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmHistoryDetailFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmHistoryDetailFacadeImpl.java
@@ -3,12 +3,17 @@
  */
 package io.holoinsight.server.home.web.controller;
 
+import io.holoinsight.server.common.DateUtil;
+import io.holoinsight.server.common.J;
 import io.holoinsight.server.home.biz.service.AlarmHistoryDetailService;
+import io.holoinsight.server.home.common.service.query.QueryResponse;
+import io.holoinsight.server.home.common.service.query.Result;
 import io.holoinsight.server.home.common.util.scope.AuthTargetType;
 import io.holoinsight.server.home.common.util.scope.MonitorScope;
 import io.holoinsight.server.home.common.util.scope.PowerConstants;
 import io.holoinsight.server.home.common.util.scope.RequestContext;
 import io.holoinsight.server.home.facade.AlarmHistoryDetailDTO;
+import io.holoinsight.server.home.facade.emuns.PeriodType;
 import io.holoinsight.server.home.facade.page.MonitorPageRequest;
 import io.holoinsight.server.home.facade.page.MonitorPageResult;
 import io.holoinsight.server.home.web.common.ManageCallback;
@@ -16,21 +21,32 @@ import io.holoinsight.server.home.web.common.ParaCheckUtil;
 import io.holoinsight.server.home.web.common.TokenUrls;
 import io.holoinsight.server.home.web.interceptor.MonitorScopeAuth;
 import io.holoinsight.server.common.JsonResult;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author wangsiyuan
  * @date 2022/6/10 11:08 上午
  */
+@Slf4j
 @RestController
 @RequestMapping("/webapi/alarmHistoryDetail")
-@TokenUrls("/webapi/alarmHistoryDetail/pageQuery")
+@TokenUrls("/webapi/alarmHistoryDetail")
 public class AlarmHistoryDetailFacadeImpl extends BaseFacade {
 
   @Autowired
@@ -65,4 +81,77 @@ public class AlarmHistoryDetailFacadeImpl extends BaseFacade {
 
     return result;
   }
+
+  @PostMapping("/countTrend")
+  @ResponseBody
+  @MonitorScopeAuth(targetType = AuthTargetType.TENANT, needPower = PowerConstants.VIEW)
+  public JsonResult<QueryResponse> queryCountTrend(
+      @RequestBody MonitorPageRequest<AlarmHistoryDetailDTO> pageRequest) {
+    final JsonResult<QueryResponse> result = new JsonResult<>();
+    facadeTemplate.manage(result, new ManageCallback() {
+      @Override
+      public void checkParameter() {
+        ParaCheckUtil.checkParaNotNull(pageRequest.getTarget(), "target");
+        ParaCheckUtil.checkParaNotNull(pageRequest.getFrom(), "from");
+        ParaCheckUtil.checkParaNotNull(pageRequest.getTo(), "to");
+      }
+
+      @Override
+      public void doManage() {
+        MonitorScope ms = RequestContext.getContext().ms;
+        if (null != ms && !StringUtils.isEmpty(ms.tenant)) {
+          pageRequest.getTarget().setTenant(ms.tenant);
+        }
+        if (null != ms && !StringUtils.isEmpty(ms.workspace)) {
+          pageRequest.getTarget().setWorkspace(ms.workspace);
+        }
+        List<Map<String, Object>> countMap = alarmHistoryDetailService.count(pageRequest);
+        QueryResponse response = new QueryResponse();
+        if (!CollectionUtils.isEmpty(countMap)) {
+          convertQueryResponse(response, countMap, pageRequest.getFrom(), pageRequest.getTo(),
+              pageRequest.getTarget());
+        }
+        result.setData(response);
+      }
+    });
+    return result;
+  }
+
+  private void convertQueryResponse(QueryResponse response, List<Map<String, Object>> countMap,
+      Long from, Long to, AlarmHistoryDetailDTO target) {
+    Map<Long, Double> values = new HashMap<>();
+    for (Map<String, Object> point : countMap) {
+      try {
+        Double value = ((Number) point.getOrDefault("c", 0d)).doubleValue();
+        Object alarmTimeObj = point.get("alarm_time");
+        Date alarmTime;
+        if (alarmTimeObj instanceof String) {
+          alarmTime = DateUtil.parseDate((String) alarmTimeObj, "yyyy-MM-dd HH:mm:ss");
+        } else if (alarmTimeObj instanceof Date) {
+          alarmTime = (Date) alarmTimeObj;
+        } else {
+          log.error("unknow case for alarmTimeObj {}", alarmTimeObj);
+          continue;
+        }
+        values.put(alarmTime.getTime(), value);
+      } catch (Exception e) {
+        log.error("fail to convert countMap {}", J.toJson(countMap), e);
+      }
+    }
+    Result result = new Result();
+    result.setValues(new ArrayList<>());
+    long end = PeriodType.MINUTE.rounding(to);
+    long start = PeriodType.MINUTE.rounding(from);
+    for (long time = end; time >= start;) {
+      Double v = values.getOrDefault(time, 0d);
+      result.getValues().add(new Object[] {time, v});
+      time -= PeriodType.MINUTE.intervalMillis();
+    }
+    if (StringUtils.isNotBlank(target.getUniqueId())) {
+      result.setTags(Collections.singletonMap("uniqueId", target.getUniqueId()));
+    }
+    result.setMetric("alert_history_detail_histogram");
+    response.setResults(Collections.singletonList(result));
+  }
+
 }

--- a/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AlertRuleIT.java
+++ b/test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AlertRuleIT.java
@@ -5,12 +5,14 @@ package io.holoinsight.server.test.it;
 
 import io.holoinsight.server.common.J;
 import io.holoinsight.server.home.facade.AlarmHistoryDTO;
+import io.holoinsight.server.home.facade.AlarmHistoryDetailDTO;
 import io.holoinsight.server.home.facade.AlarmRuleDTO;
 import io.holoinsight.server.home.facade.Rule;
 import io.holoinsight.server.home.facade.TimeFilter;
 import io.holoinsight.server.home.facade.emuns.BoolOperationEnum;
 import io.holoinsight.server.home.facade.emuns.CompareOperationEnum;
 import io.holoinsight.server.home.facade.emuns.FunctionEnum;
+import io.holoinsight.server.home.facade.emuns.PeriodType;
 import io.holoinsight.server.home.facade.emuns.TimeFilterEnum;
 import io.holoinsight.server.home.facade.page.MonitorPageRequest;
 import io.holoinsight.server.home.facade.trigger.CompareConfig;
@@ -26,6 +28,7 @@ import org.hamcrest.core.Every;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.springframework.util.CollectionUtils;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -296,6 +299,40 @@ public class AlertRuleIT extends BaseIT {
               .then() //
               .body("success", IS_TRUE) //
               .body("data.items.size()", gt(0));
+
+          AlarmHistoryDetailDTO detailDTO = new AlarmHistoryDetailDTO();
+          detailDTO.setUniqueId(uniqueId);
+          MonitorPageRequest<AlarmHistoryDetailDTO> detailPageRequest = new MonitorPageRequest<>();
+          long end = System.currentTimeMillis();
+          long start = end - PeriodType.MINUTE.intervalMillis() * 10L;
+          detailPageRequest.setFrom(start);
+          detailPageRequest.setTo(end);
+          detailPageRequest.setTarget(detailDTO);
+          given() //
+              .body(new JSONObject(J.toMap(J.toJson(detailPageRequest)))) //
+              .when() //
+              .post("/webapi/alarmHistoryDetail/countTrend") //
+              .then() //
+              .body("success", IS_TRUE) //
+              .root("data") //
+              .body("results", hasItem(
+                  new CustomMatcher<Map<String, Object>>("check alert history detail count") {
+                    @Override
+                    public boolean matches(Object o) {
+                      Map<String, Object> result = (Map<String, Object>) o;
+                      List<List<Object>> values = (List<List<Object>>) result.get("values");
+                      for (List<Object> item : values) {
+                        if (!CollectionUtils.isEmpty(item) && item.size() > 1
+                            && item.get(1) instanceof Number) {
+                          boolean checkResult = ((Number) item.get(1)).longValue() > 0;
+                          if (checkResult) {
+                            return true;
+                          }
+                        }
+                      }
+                      return false;
+                    }
+                  }));
         });
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Provide an interface to return the quantity of alert history detail in a time-series data format, which can be used for displaying event monitoring dashboard on the frontend.

# What changes are included in this PR?

- Add `/webapi/alarmHistoryDetail/countTrend ` in `server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmHistoryDetailFacadeImpl.java`

# Are there any user-facing changes?

None.

# How does this change test

E2E test: `test/server-e2e-test/src/main/java/io/holoinsight/server/test/it/AlertRuleIT.java`
