### PR TITLE
fix: remove redundant targets

### DIFF
--- a/server/registry/registry-core/src/main/java/io/holoinsight/server/registry/core/collecttarget/CollectTargetStorage.java
+++ b/server/registry/registry-core/src/main/java/io/holoinsight/server/registry/core/collecttarget/CollectTargetStorage.java
@@ -125,6 +125,9 @@ public class CollectTargetStorage {
         byTemplate.computeIfAbsent(templateId, i -> MapSetUtils.newCHS());
     for (CollectTarget t : combs) {
       CollectTargetKey key = t.getKey();
+
+      this.delete(key);
+
       byKey.put(key, t);
       templateKeys.add(key);
       MapSetUtils.addMapSetKey(byAgent, t.getRefAgent(), key);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When a statefulset pod move from one node to another. Its namespace and podName doesn't change.
In the holoinsight server side, the pod meta uk is calculated by namespace, podName ...
So its uk stays the same.

In `io.holoinsight.server.registry.core.collecttarget.CollectTargetMaintainer#maintainTemplate1`, when statefulset pod move to another node, its `refAgent` is changed, and leading to a target update, which finally calls `io.holoinsight.server.registry.core.collecttarget.CollectTargetStorage#batchPut`.

In `batchPut`, it didn't delete the old target index `byAgent`. So the old `refAgent` index still owns the target, which leads to redundant tasks running on wrong agent.

# What changes are included in this PR?
- Remove redundant targets

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
