### PR TITLE
fix: fix APM metrics meta query

### DIFF
--- a/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/specification/OtlpMappings.java
+++ b/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/specification/OtlpMappings.java
@@ -43,7 +43,7 @@ public class OtlpMappings {
 
   /**
    * null -> null <br>
-   * tenant -> resource.tenant <br>
+   * for holoinsight-span: tenant -> resource.tenant <br>
    * serviceName -> resource.service.name <br>
    * serviceInstanceName -> resource.service.instance.name <br>
    * endpointName -> name <br>
@@ -56,10 +56,10 @@ public class OtlpMappings {
    * @return
    */
   public static String toOtlp(String index, String name) {
-    if (name == null) {
-      return null;
+    BiMap<String, String> mappings = OTLP_SW_MAPPINGS.get(index);
+    if (mappings == null || name == null) {
+      return name;
     }
-    BiMap<String, String> mappings = OTLP_SW_MAPPINGS.getOrDefault(index, HashBiMap.create());
     if (mappings.containsKey(name)) {
       return mappings.get(name);
     }
@@ -73,7 +73,7 @@ public class OtlpMappings {
 
   /**
    * null -> null <br>
-   * resource.tenant -> tenant <br>
+   * for holoinsight-span: resource.tenant -> tenant <br>
    * resource.service.name -> serviceName <br>
    * resource.service.instance.name -> serviceInstanceName <br>
    * name -> endpointName <br>
@@ -84,12 +84,11 @@ public class OtlpMappings {
    * @return
    */
   public static String fromOtlp(String index, String name) {
-
-    if (name == null) {
-      return null;
+    BiMap<String, String> mappings = OTLP_SW_MAPPINGS.get(index);
+    if (mappings == null || name == null) {
+      return name;
     }
-    BiMap<String, String> mappings =
-        OTLP_SW_MAPPINGS.getOrDefault(index, HashBiMap.create()).inverse();
+    mappings = mappings.inverse();
     if (mappings.containsKey(name)) {
       return mappings.get(name);
     }

--- a/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/specification/sw/ServiceRelation.java
+++ b/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/specification/sw/ServiceRelation.java
@@ -15,6 +15,7 @@ public class ServiceRelation extends Source {
   @Getter
   @Setter
   private String sourceServiceName;
+
   @Getter
   @Setter
   private String sourceServiceInstanceName;

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanMetricEsStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanMetricEsStorage.java
@@ -62,7 +62,8 @@ public class SpanMetricEsStorage extends PostCalMetricStorage {
 
 
     boolQueryBuilder
-        .filter(new TermQueryBuilder(OtlpMappings.toOtlp(metricDefine.getIndex(), Const.TENANT), tenant))
+        .filter(new TermQueryBuilder(OtlpMappings.toOtlp(metricDefine.getIndex(), Const.TENANT),
+            tenant))
         .filter(new RangeQueryBuilder(timeField()).gte(duration.getStart()).lte(duration.getEnd()));
 
     if (conditions != null) {

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanMetricEsStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanMetricEsStorage.java
@@ -3,6 +3,7 @@
  */
 package io.holoinsight.server.apm.engine.elasticsearch.storage.impl;
 
+import io.holoinsight.server.apm.common.constants.Const;
 import io.holoinsight.server.apm.common.model.query.Duration;
 import io.holoinsight.server.apm.common.model.query.MetricValue;
 import io.holoinsight.server.apm.common.model.query.MetricValues;
@@ -58,7 +59,10 @@ public class SpanMetricEsStorage extends PostCalMetricStorage {
     MetricValues metricValues = new MetricValues(values);
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
-    boolQueryBuilder.filter(new TermQueryBuilder(SpanDO.resource(SpanDO.TENANT), tenant))
+
+
+    boolQueryBuilder
+        .filter(new TermQueryBuilder(OtlpMappings.toOtlp(metricDefine.getIndex(), Const.TENANT), tenant))
         .filter(new RangeQueryBuilder(timeField()).gte(duration.getStart()).lte(duration.getEnd()));
 
     if (conditions != null) {

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/model/ServiceRelationDO.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/model/ServiceRelationDO.java
@@ -25,6 +25,7 @@ public class ServiceRelationDO extends RecordDO {
   public static final String START_TIME = "start_time";
   public static final String END_TIME = "end_time";
   public static final String SOURCE_SERVICE_NAME = "source_service_name";
+
   public static final String DEST_SERVICE_NAME = "dest_service_name";
   public static final String COMPONENT = "component";
   public static final String TRACE_STATUS = "trace_status";

--- a/server/apm/apm-server/apm-engine/src/main/resources/metrics/metrics.json
+++ b/server/apm/apm-server/apm-engine/src/main/resources/metrics/metrics.json
@@ -329,9 +329,13 @@
     "index": "holoinsight-service_relation",
     "field": "trace_id",
     "function": "cardinality",
-    "groups": [],
+    "groups": [
+      "source_service_name",
+      "dest_service_name",
+      "component",
+      "type"
+    ],
     "conditions": {
-      "type": "MQ"
     },
     "materialized": true
   },
@@ -340,9 +344,13 @@
     "index": "holoinsight-service_relation",
     "field": "trace_id",
     "function": "cardinality",
-    "groups": [],
+    "groups": [
+      "source_service_name",
+      "dest_service_name",
+      "component",
+      "type"
+    ],
     "conditions": {
-      "type": "MQ"
     },
     "materializedExp": "sum{apm_component_cpm_materialized}"
   },
@@ -351,9 +359,13 @@
     "index": "holoinsight-service_relation",
     "field": "trace_id",
     "function": "cardinality",
-    "groups": [],
+    "groups": [
+      "source_service_name",
+      "dest_service_name",
+      "component",
+      "type"
+    ],
     "conditions": {
-      "type": "MQ",
       "is_error": "1"
     },
     "materialized": true
@@ -363,9 +375,13 @@
     "index": "holoinsight-service_relation",
     "field": "trace_id",
     "function": "cardinality",
-    "groups": [],
+    "groups": [
+      "source_service_name",
+      "dest_service_name",
+      "component",
+      "type"
+    ],
     "conditions": {
-      "type": "MQ",
       "is_error": "1"
     },
     "materializedExp": "sum{apm_component_cpm_fail_materialized}"
@@ -375,9 +391,13 @@
     "index": "holoinsight-service_relation",
     "field": "latency",
     "function": "sum",
-    "groups": [],
+    "groups": [
+      "source_service_name",
+      "dest_service_name",
+      "component",
+      "type"
+    ],
     "conditions": {
-      "type": "MQ"
     },
     "materialized": true
   },
@@ -386,9 +406,13 @@
     "index": "holoinsight-service_relation",
     "field": "latency",
     "function": "avg",
-    "groups": [],
+    "groups": [
+      "source_service_name",
+      "dest_service_name",
+      "component",
+      "type"
+    ],
     "conditions": {
-      "type": "MQ"
     },
     "materializedExp": "sum{apm_component_resp_time_total_materialized}/sum{apm_component_cpm_materialized}"
   },
@@ -397,9 +421,13 @@
     "index": "holoinsight-service_relation",
     "field": "latency",
     "function": "percentiles",
-    "groups": [],
+    "groups": [
+      "source_service_name",
+      "dest_service_name",
+      "component",
+      "type"
+    ],
     "conditions": {
-      "type": "MQ"
     }
   }
 ]

--- a/server/apm/apm-server/apm-receiver/src/main/java/io/holoinsight/server/apm/receiver/builder/RPCTrafficSourceBuilder.java
+++ b/server/apm/apm-server/apm-receiver/src/main/java/io/holoinsight/server/apm/receiver/builder/RPCTrafficSourceBuilder.java
@@ -17,6 +17,7 @@ public class RPCTrafficSourceBuilder extends EndpointSourceBuilder {
   @Getter
   @Setter
   private String sourceServiceName;
+
   @Getter
   @Setter
   private Layer sourceLayer;

--- a/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/DefaultQueryServiceImpl.java
+++ b/server/query/query-service/src/main/java/io/holoinsight/server/query/service/impl/DefaultQueryServiceImpl.java
@@ -120,12 +120,23 @@ public class DefaultQueryServiceImpl implements QueryService {
       Map<String, Set<String>> keys = new HashMap<>();
       List<QueryProto.Datasource> datasources = request.getDatasourcesList();
       for (QueryProto.Datasource ds : datasources) {
-        QueryParam queryParam = new QueryParam();
-        queryParam.setMetric(ds.getMetric());
-        queryParam.setTenant(request.getTenant());
-        Result result = metricStorage.querySchema(queryParam);
-        Map<String, String> tags = result.getTags();
-        keys.put(ds.getMetric(), tags.keySet());
+        if (this.apmMetrics.getUnchecked(request.getTenant()).containsKey(ds.getMetric())) {
+          Response<List<String>> schemaRsp = apmClient.getClient(request.getTenant())
+              .querySchema(new QueryMetricRequest(request.getTenant(), ds.getMetric(), null, null))
+              .execute();
+          if (!schemaRsp.isSuccessful()) {
+            throw new QueryException(schemaRsp.errorBody().string());
+          }
+          builder.addResults(QueryProto.KeysResult.newBuilder().setMetric(ds.getMetric())
+              .addAllKeys(schemaRsp.body()).build());
+        } else {
+          QueryParam queryParam = new QueryParam();
+          queryParam.setMetric(ds.getMetric());
+          queryParam.setTenant(request.getTenant());
+          Result result = metricStorage.querySchema(queryParam);
+          Map<String, String> tags = result.getTags();
+          keys.put(ds.getMetric(), tags.keySet());
+        }
       }
       keys.forEach((m, ks) -> builder
           .addResults(QueryProto.KeysResult.newBuilder().setMetric(m).addAllKeys(ks)).build());
@@ -137,16 +148,36 @@ public class DefaultQueryServiceImpl implements QueryService {
   public QueryProto.QueryMetricsResponse queryMetrics(QueryProto.QueryMetricsRequest request)
       throws QueryException {
     return wrap(() -> {
+
+      QueryProto.QueryMetricsResponse.Builder b = QueryProto.QueryMetricsResponse.newBuilder();
+
+      Set<String> metrics = new HashSet<>();
+
       QueryMetricsParam param = QueryStorageUtils.convertToQueryMetricsParam(request);
       List<String> suggestRsp = metricStorage.queryMetrics(param);
 
-      QueryProto.QueryMetricsResponse.Builder b = QueryProto.QueryMetricsResponse.newBuilder();
       if (CollectionUtils.isNotEmpty(suggestRsp)) {
         for (String metric : suggestRsp) {
-          QueryProto.MetricResult mr = QueryProto.MetricResult.newBuilder().setName(metric).build();
-          b.addResults(mr);
+          metrics.add(metric);
         }
       }
+
+      Map<String, MetricDefine> apmMetrics = this.apmMetrics.getUnchecked(request.getTenant());
+      if (apmMetrics != null) {
+        for (String apmMetric : apmMetrics.keySet()) {
+          if (StringUtils.isBlank(request.getName())
+              || request.getExplicit() && StringUtils.equals(apmMetric, request.getName())
+              || !request.getExplicit() && StringUtils.contains(apmMetric, request.getName())) {
+            metrics.add(apmMetric);
+          }
+        }
+      }
+
+      metrics.forEach(metric -> {
+        QueryProto.MetricResult mr = QueryProto.MetricResult.newBuilder().setName(metric).build();
+        b.addResults(mr);
+      });
+
       return b.build();
     }, "queryMetrics", request);
   }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
This PR is to do special processing for APM-related meta-information queries, so as to correctly return relevant information.


<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Modify the `querySchema` and `queryMetrics` functions to do special processing for APM metrics.
- Corrected grouping of `apm-component*` related metrics.


<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Users can now correctly query the meta information of APM indicators.


<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI and E2E tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
