### PR TITLE
feat: Support for using MySQL to store metadata

### DIFF
--- a/server/extension/extension-common-flyway/src/main/resources/db/migration/V7__230427_ADD_meta_dim_data_TABLE.sql
+++ b/server/extension/extension-common-flyway/src/main/resources/db/migration/V7__230427_ADD_meta_dim_data_TABLE.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+-- ----------------------------
+-- Table structure for meta_data
+-- ----------------------------
+CREATE TABLE IF NOT EXISTS `meta_dim_data` (
+    `id` bigint NOT NULL AUTO_INCREMENT COMMENT 'Data id',
+    `gmt_create` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Data creation time',
+    `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Data modification time',
+    `table_name` varchar(256) NOT NULL COMMENT 'Table name',
+    `uk` varchar(256) NOT NULL COMMENT 'Meta data uk',
+    `json` longtext COMMENT 'Json data, json format of metadata',
+    `annotations` longtext COMMENT 'annotations message',
+    `deleted` tinyint NOT NULL COMMENT 'Softed delete, when 1 indicates that the configuration has been deleted',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ux_table_name_uk` (`table_name`,`uk`)  USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Meta data';

--- a/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxMetricStorage.java
+++ b/server/extension/extension-storage-ceresdbx/src/main/java/io/holoinsight/server/extension/ceresdbx/CeresdbxMetricStorage.java
@@ -215,11 +215,11 @@ public class CeresdbxMetricStorage implements MetricStorage {
           StatUtils.STORAGE_WRITE.add(StringsKey.of("CeresDBx", tenant, "N"),
               new long[] {1, oneBatch.size(), System.currentTimeMillis() - start});
           if (result != null && null != result.getErr()) {
-            LOGGER.error("save metrics:{} to CeresDBx result:{}, error msg:{}", metrics, result,
+            LOGGER.error("save metrics:{} to CeresDBx error msg:{}", metrics,
                 result.getErr().getError());
           } else if (null != throwable) {
-            LOGGER.error("save metrics:{} to CeresDBx result:{}, error msg:{}", metrics, result,
-                throwable);
+            LOGGER.error("save metrics:{} to CeresDBx error msg:{}", metrics,
+                throwable.getMessage(), throwable);
           } else {
             LOGGER.error("save metrics:{} to CeresDBx error", metrics);
           }

--- a/server/meta/meta-boot/src/main/java/io/holoinsight/server/meta/bootstrap/MetaMongoDBConfig.java
+++ b/server/meta/meta-boot/src/main/java/io/holoinsight/server/meta/bootstrap/MetaMongoDBConfig.java
@@ -8,6 +8,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,6 +17,8 @@ import org.springframework.context.annotation.Configuration;
  * @version 1.0: MongoDBConfig.java, Date: 2023-04-18 Time: 20:17
  */
 @Configuration
+@ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mongodb",
+    matchIfMissing = true)
 public class MetaMongoDBConfig {
 
   @Value("${spring.data.mongodb.uri}")

--- a/server/meta/meta-bootstrap/src/main/resources/config/application.yaml
+++ b/server/meta/meta-bootstrap/src/main/resources/config/application.yaml
@@ -34,3 +34,9 @@ management:
 holoinsight:
   roles:
     active: meta
+
+mybatis-plus:
+  config-location: classpath:mybatis/mybatis-config.xml
+  mapper-locations:
+    - classpath*:sqlmap/*.xml
+    - classpath*:sqlmap-ext/*.xml

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.meta.core;
+
+import com.mongodb.client.MongoDatabase;
+import io.holoinsight.server.meta.core.service.DBCoreService;
+import io.holoinsight.server.meta.core.service.MongoDataCoreService;
+import io.holoinsight.server.meta.core.service.SqlDataCoreService;
+import io.holoinsight.server.meta.dal.service.mapper.MetaDataMapper;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author jinyan.ljw
+ * @Description MetaServiceConfiguration
+ * @date 2023/4/27
+ */
+@Configuration
+@MapperScan(basePackages = {"io.holoinsight.server.meta.dal.service.mapper"})
+public class MetaServiceConfiguration {
+
+  @Bean("mongoDataCoreService")
+  @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mongodb",
+      matchIfMissing = true)
+  public DBCoreService MongoDataCoreService(MongoDatabase mongoDatabase) {
+    return new MongoDataCoreService(mongoDatabase);
+  }
+
+  @Bean("sqlDataCoreService")
+  // @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mysql")
+  public DBCoreService SqlDataCoreService(MetaDataMapper metaDataMapper) {
+    return new SqlDataCoreService(metaDataMapper);
+  }
+}

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/common/FilterUtil.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/common/FilterUtil.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.meta.core.common;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.collect.Maps;
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.meta.common.model.QueryExample;
+import org.springframework.util.CollectionUtils;
+
+import static io.holoinsight.server.meta.common.util.ConstModel.default_hostname;
+import static io.holoinsight.server.meta.common.util.ConstModel.default_ip;
+
+/**
+ * @author jinyan.ljw
+ * @Description TODO
+ * @date 2023/5/20
+ */
+public class FilterUtil {
+
+
+  public static final String REGEX_FILTERS_KEY = "regexFilters";
+  public static final String EQ_FILTERS_KEY = "eqFilters";
+  public static final String IN_FILTERS_KEY = "inFilters";
+
+  public static Map<String, Map<String, Object>> buildFilters(QueryExample queryExample,
+      Boolean containRegexFilters) {
+    Map<String, Map<String, Object>> filters = Maps.newHashMap();
+    if (CollectionUtils.isEmpty(queryExample.getParams())) {
+      return filters;
+    }
+    for (Map.Entry<String, Object> entry : queryExample.getParams().entrySet()) {
+      Object value = entry.getValue();
+      if (Objects.isNull(value)) {
+        continue;
+      }
+      String key = entry.getKey();
+      if (containRegexFilters && (key.equals(default_ip) || key.equals(default_hostname))) {
+        Map<String, Object> regexFilters =
+            filters.computeIfAbsent(REGEX_FILTERS_KEY, k -> Maps.newHashMap());
+        Pattern pattern = J.json2Bean(J.toJson(value), Pattern.class);
+        regexFilters.put(key, pattern);
+        continue;
+      }
+      if (value instanceof String) {
+        Map<String, Object> eqFilters =
+            filters.computeIfAbsent(EQ_FILTERS_KEY, k -> Maps.newHashMap());
+        eqFilters.put(key, value.toString());
+      } else if (value instanceof List) {
+        if (CollectionUtils.isEmpty((List) value)) {
+          continue;
+        }
+        Map<String, Object> inFilters =
+            filters.computeIfAbsent(IN_FILTERS_KEY, k -> Maps.newHashMap());
+        inFilters.put(key, value);
+      }
+    }
+    return filters;
+  }
+
+
+  public static <R> List<R> filterData(Collection<Map<String, Object>> items,
+      Map<String, Map<String, Object>> filters, Function<Map, R> func) {
+    Map<String, Object> eqFilters = filters.get(EQ_FILTERS_KEY);
+    Stream<Map<String, Object>> dataStream = items.stream();
+    if (eqFilters != null) {
+      dataStream = dataStream.filter(item -> {
+        for (Entry<String, Object> eqItem : eqFilters.entrySet()) {
+          String eqItemKey = eqItem.getKey();
+          Object realVal = getRealVal(eqItemKey, item);
+          Object eqItemValue = eqItem.getValue();
+          if (!Objects.equals(realVal, eqItemValue)) {
+            return false;
+          }
+        }
+        return true;
+      });
+    }
+    Map<String, Object> inFilters = filters.get(IN_FILTERS_KEY);
+    if (inFilters != null) {
+      dataStream = dataStream.filter(item -> {
+        for (Entry<String, Object> inItem : inFilters.entrySet()) {
+          String inItemKey = inItem.getKey();
+          Object realVal = getRealVal(inItemKey, item);
+          List<String> inItemValue = (List<String>) inItem.getValue();
+          if (Objects.isNull(realVal) || !inItemValue.contains(realVal)) {
+            return false;
+          }
+        }
+        return true;
+      });
+    }
+    Map<String, Object> regexFilters = filters.get(REGEX_FILTERS_KEY);
+    if (regexFilters != null) {
+      dataStream = dataStream.filter(item -> {
+        for (Entry<String, Object> regexItem : regexFilters.entrySet()) {
+          String regexItemKey = regexItem.getKey();
+          Object realVal = getRealVal(regexItemKey, item);
+          Pattern pattern = (Pattern) regexItem.getValue();
+          if (Objects.isNull(realVal) || !pattern.matcher(realVal.toString()).matches()) {
+            return false;
+          }
+        }
+        return true;
+      });
+    }
+    return dataStream.map(func).collect(Collectors.toList());
+  }
+
+
+  private static Object getRealVal(String key, Map<String, Object> map) {
+    if (key.contains(".")) {
+      String[] eqItemKeys = key.split("\\.");
+      Object value0 = map.get(eqItemKeys[0]);
+      if (Objects.isNull(value0)) {
+        return null;
+      }
+      Map<String, Object> keyItem = (Map<String, Object>) value0;
+      return keyItem.get(eqItemKeys[1]);
+    } else {
+      return map.get(key);
+    }
+  }
+
+}

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/DBCoreService.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/DBCoreService.java
@@ -18,9 +18,6 @@ public interface DBCoreService {
 
   Pair<Integer, Integer> insertOrUpdate(String tableName, List<Map<String, Object>> rows);
 
-  List<Map<String, Object>> updateByExample(String tableName, QueryExample queryExample,
-      Map<String, Object> row);
-
   List<Map<String, Object>> queryByTable(String tableName);
 
   List<Map<String, Object>> queryByTable(String tableName, List<String> rowKeys);

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.meta.core.service;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.common.Pair;
+import io.holoinsight.server.meta.common.model.QueryExample;
+import io.holoinsight.server.meta.core.common.FilterUtil;
+import io.holoinsight.server.meta.dal.service.mapper.MetaDataMapper;
+import io.holoinsight.server.meta.dal.service.model.MetaData;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.StopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+/**
+ *
+ * @author jiwliu
+ * @version 1.0: SqlDataCoreService.java, v 0.1 2022年03月07日 9:13 下午 jinsong.yjs Exp $
+ */
+public class SqlDataCoreService extends AbstractDataCoreService {
+
+  public static final Logger logger = LoggerFactory.getLogger(SqlDataCoreService.class);
+
+  public static final int BATCH_INSERT_SIZE = 5;
+  public static final int LIMIT = 1000;
+  public static final int PERIOD = 30;
+  public static final int DELETED = 1;
+  public static final String MODIFIED_FIELD = "_modified";
+  public static final String ANNOTATIONS_FIELD = "annotations";
+  private MetaDataMapper metaDataMapper;
+
+  // tableName ---> Map(uk ---> Map(key ---> value))
+  private Map<String, Map<String, Map<String, Object>>> metaCache;
+  private volatile long last = -1;
+  private AtomicBoolean syncing = new AtomicBoolean(false);
+  private final long interval = PERIOD * 1000;
+  public static final ScheduledThreadPoolExecutor scheduledExecutor =
+      new ScheduledThreadPoolExecutor(2, r -> new Thread(r, "meta-sync-scheduler"));
+
+  public SqlDataCoreService(MetaDataMapper metaDataMapper) {
+    this.metaDataMapper = metaDataMapper;
+    metaCache = new HashMap<>();
+    sync();
+    scheduledExecutor.scheduleAtFixedRate(this::sync, PERIOD, PERIOD, TimeUnit.SECONDS);
+  }
+
+  /**
+   * load meta data
+   */
+  private void sync() {
+    StopWatch stopWatch = StopWatch.createStarted();
+    long now = System.currentTimeMillis() / 1000 * 1000;
+    if (now - last >= interval) {
+      if (syncing.compareAndSet(false, true)) {
+        try {
+          if (last < 0) {
+            int count = queryChangedMeta(new Date(0), new Date(now), false, dealUpdatedMeta());
+            logger.info("[FullCache] init query success, size={}, now={}, cost={}", count, now,
+                stopWatch.getTime());
+          } else {
+            int count =
+                queryChangedMeta(new Date(last - 2000), new Date(now), true, dealUpdatedMeta());
+            logger.info("[FullCache] sync query success, size={}, last={}, now={}, cost={}", count,
+                last, now, stopWatch.getTime());
+          } ;
+          logger.info("[FullCache] sync success, last={}, now={}, cost={}", last, now,
+              stopWatch.getTime());
+        } catch (Exception e) {
+          logger.error("[FullCache] sync fail, last={}, now={}", last, now, e);
+        } finally {
+          last = now;
+          syncing.compareAndSet(true, false);
+        }
+      }
+    }
+  }
+
+  /**
+   * update meta cache
+   * 
+   * @return
+   */
+  private Consumer<List<MetaData>> dealUpdatedMeta() {
+    return data -> data.forEach(metaData -> {
+      Map<String, Map<String, Object>> items =
+          metaCache.computeIfAbsent(metaData.getTableName(), k -> Maps.newConcurrentMap());
+      if (metaData.getDeleted() == DELETED) {
+        items.remove(metaData.getUk());
+      } else {
+        items.put(metaData.getUk(), J.toMap(metaData.getJson()));
+      }
+    });
+  }
+
+  private Integer queryChangedMeta(Date start, Date end, Boolean containDeleted,
+      Consumer<List<MetaData>> listConsumer) {
+    int offset = 0;
+    int count = 0;
+    while (true) {
+      List<MetaData> metaDataList =
+          metaDataMapper.queryChangedMeta(start, end, containDeleted, offset, LIMIT);
+      offset += LIMIT;
+      if (metaDataList.isEmpty()) {
+        break;
+      }
+      count += metaDataList.size();
+      listConsumer.accept(metaDataList);
+    }
+    return count;
+  }
+
+  @Override
+  public Pair<Integer, Integer> insertOrUpdate(String tableName, List<Map<String, Object>> rows) {
+    logger.info("[insertOrUpdate] start, table={}, records={}.", tableName, rows.size());
+    if (CollectionUtils.isEmpty(rows)) {
+      return new Pair<>(0, 0);
+    }
+    try {
+      List<Map<String, Object>> filterRows = addUkValues(tableName, rows);
+      StopWatch stopWatch = StopWatch.createStarted();
+      Map<String, Map<String, Object>> ukToUpdateOrInsertRow = Maps.newHashMap();
+      filterRows.forEach(item -> {
+        String uk = item.getOrDefault("_uk", "").toString();
+        ukToUpdateOrInsertRow.put(uk, item);
+      });
+      List<MetaData> metaDataList =
+          metaDataMapper.selectByUks(tableName, ukToUpdateOrInsertRow.keySet());
+      Pair<Integer, Integer> sameAndExistSize;
+      if (!CollectionUtils.isEmpty(metaDataList)) {
+        sameAndExistSize = doUpdate(tableName, metaDataList, ukToUpdateOrInsertRow);
+      } else {
+        sameAndExistSize = new Pair<>(0, 0);
+      }
+      Integer addedSize = doInsert(tableName, ukToUpdateOrInsertRow);
+      int modifiedCount = sameAndExistSize.right() - sameAndExistSize.left();
+      int upsertSize = addedSize + modifiedCount;
+      logger.info(
+          "[insertOrUpdate]finish, table={}, upsertSize={}, matchedCount={}, modifiedCount={}, cost={}.",
+          tableName, upsertSize, sameAndExistSize.right(), modifiedCount, stopWatch.getTime());
+      return new Pair<>(upsertSize, modifiedCount);
+    } catch (Exception e) {
+      logger.error("[insertOrUpdate] fail, table={}, rows={}, contents={}.", tableName, rows.size(),
+          rows, e);
+      return new Pair<>(0, 0);
+    }
+  }
+
+  private Integer doInsert(String tableName,
+      Map<String, Map<String, Object>> ukToUpdateOrInsertRow) {
+    if (ukToUpdateOrInsertRow.isEmpty()) {
+      return 0;
+    }
+    List<String> addedUks = Lists.newArrayList();
+    List<MetaData> metaDataList = Lists.newArrayList();
+    ukToUpdateOrInsertRow.forEach((uk, row) -> {
+      addedUks.add(uk);
+      MetaData metaData = new MetaData();
+      metaData.setUk(uk);
+      metaData.setTableName(tableName);
+      metaData.setDeleted(0);
+      Object annotations = row.remove(ANNOTATIONS_FIELD);
+      if (annotations != null) {
+        metaData.setAnnotations(J.toJson(annotations));
+      }
+      metaData.setJson(J.toJson(row));
+      metaData.setGmtCreate(new Date());
+      metaData.setGmtModified(new Date());
+      metaDataList.add(metaData);
+    });
+    if (!CollectionUtils.isEmpty(metaDataList)) {
+      Lists.partition(metaDataList, BATCH_INSERT_SIZE)
+          .forEach(list -> metaDataMapper.batchInsertOrUpdate(list));
+    }
+    logger.info("[insertOrUpdate] insert finish, uks:{}", addedUks);
+    return addedUks.size();
+  }
+
+  private Pair<Integer, Integer> doUpdate(String tableName, List<MetaData> metaDataList,
+      Map<String, Map<String, Object>> ukToUpdateOrInsertRow) {
+    Map<String, Map<String, Object>> ukToRowCache =
+        metaCache.getOrDefault(tableName, Maps.newConcurrentMap());
+    List<String> existUks = new ArrayList<>(metaDataList.size());
+    List<String> sameUks = new ArrayList<>(metaDataList.size());
+    for (MetaData metaData : metaDataList) {
+      String uk = metaData.getUk();
+      existUks.add(uk);
+      Map<String, Object> updateOrInsertRow = ukToUpdateOrInsertRow.remove(uk);
+      Map<String, Object> cachedRow = ukToRowCache.get(uk);
+      Pair<Boolean, Object> sameWithDbAnnotations =
+          sameWithDbAnnotations(metaData, updateOrInsertRow);
+      if (sameWithCache(updateOrInsertRow, cachedRow) && sameUks.add(uk)
+          && sameWithDbAnnotations.left()) {
+        continue;
+      }
+      if (!sameWithDbAnnotations.left()) {
+        if (Objects.isNull(sameWithDbAnnotations.right())) {
+          metaData.setAnnotations(J.toJson(new HashMap<String, Object>()));
+        } else {
+          metaData.setAnnotations(J.toJson(sameWithDbAnnotations.right()));
+        }
+      }
+      Map<String, Object> sourceRow = J.toMap(metaData.getJson());
+      sourceRow.putAll(updateOrInsertRow);
+      metaData.setJson(J.toJson(sourceRow));
+      metaData.setGmtModified(new Date());
+      metaDataMapper.updateByUk(tableName, metaData);
+    }
+    logger.info("[insertOrUpdate] update finish, update same uks:{}, existUks:{}", sameUks,
+        existUks);
+    return new Pair<>(sameUks.size(), existUks.size());
+  }
+
+  /**
+   *
+   * @param metaData
+   * @param updateOrInsertRow
+   * @return
+   */
+  private Pair<Boolean, Object> sameWithDbAnnotations(MetaData metaData,
+      Map<String, Object> updateOrInsertRow) {
+    Object annotations = updateOrInsertRow.remove(ANNOTATIONS_FIELD);
+    Map<String, Object> extraMap = null;
+    String dbAnnotations = metaData.getAnnotations();
+    if (StringUtils.isNotBlank(dbAnnotations)) {
+      extraMap = J.toMap(metaData.getAnnotations());
+    }
+    if (Objects.equals(extraMap, annotations)) {
+      return new Pair<>(true, null);
+    }
+    return new Pair<>(false, annotations);
+  }
+
+  private boolean sameWithCache(Map<String, Object> updateOrInsertRow,
+      Map<String, Object> cachedRow) {
+    if (CollectionUtils.isEmpty(cachedRow)) {
+      return false;
+    }
+    Set<String> keys = updateOrInsertRow.keySet();
+    for (String key : keys) {
+      if (!MODIFIED_FIELD.equalsIgnoreCase(key)
+          && !Objects.equals(updateOrInsertRow.get(key), cachedRow.get(key))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public List<Map<String, Object>> queryByTable(String tableName) {
+    return queryByTable(tableName, Lists.newArrayList());
+  }
+
+  @Override
+  public List<Map<String, Object>> queryByTable(String tableName, List<String> rowKeys) {
+    logger.info("[queryByTable] start, table={}, rowsKeys={}.", tableName, rowKeys);
+    StopWatch stopWatch = StopWatch.createStarted();
+    Map<String, Map<String, Object>> ukToRowCache =
+        metaCache.getOrDefault(tableName, Maps.newConcurrentMap());
+    List<Map<String, Object>> results;
+    if (!CollectionUtils.isEmpty(rowKeys)) {
+      results = ukToRowCache.values().stream()
+          .map(data -> data.entrySet().stream().filter(entry -> rowKeys.contains(entry.getKey()))
+              .collect(Collectors.toMap(Entry::getKey, Entry::getValue)))
+          .collect(Collectors.toList());
+    } else {
+      results = new ArrayList<>(ukToRowCache.values());
+    }
+    logger.info("[queryByTable] finish, table={}, records={}, cost={}.", tableName, results.size(),
+        stopWatch.getTime());
+    return results;
+  }
+
+  @Override
+  public List<Map<String, Object>> queryByPks(String tableName, List<String> pkValList) {
+    logger.info("[queryByPks] start, table={}, pkValList={}.", tableName, pkValList.size());
+    Map<String, Map<String, Object>> ukToRowCache =
+        metaCache.getOrDefault(tableName, Maps.newConcurrentMap());
+    if (CollectionUtils.isEmpty(pkValList) || null == ukToRowCache) {
+      return Lists.newArrayList();
+    }
+    StopWatch stopWatch = StopWatch.createStarted();
+    List<Map<String, Object>> result = Lists.newArrayList();
+    pkValList.forEach(uk -> {
+      Map<String, Object> item = ukToRowCache.get(uk);
+      if (!CollectionUtils.isEmpty(item)) {
+        result.add(item);
+      }
+    });
+    logger.info("[queryByPks] finish, table={}, records={}, cost={}.", tableName, result.size(),
+        stopWatch.getTime());
+    return result;
+  }
+
+  @Override
+  public List<Map<String, Object>> queryByExample(String tableName, QueryExample queryExample) {
+    logger.info("[queryByExample] start, table={}, queryExample={}.", tableName,
+        J.toJson(queryExample));
+    StopWatch stopWatch = StopWatch.createStarted();
+    Map<String, Map<String, Object>> filters = FilterUtil.buildFilters(queryExample, false);
+    Map<String, Map<String, Object>> ukToRowCache = metaCache.get(tableName);
+    if (CollectionUtils.isEmpty(ukToRowCache)) {
+      return Lists.newArrayList();
+    }
+    List<Map<String, Object>> rows = FilterUtil.filterData(ukToRowCache.values(), filters, v -> v);
+    logger.info("[queryByExample] finish, table={}, records={}, cost={}.", tableName, rows.size(),
+        stopWatch.getTime());
+    return rows;
+  }
+
+  @Override
+  public List<Map<String, Object>> fuzzyByExample(String tableName, QueryExample queryExample) {
+    logger.info("[fuzzyByExample] start, table={}, queryExample={}.", tableName,
+        J.toJson(queryExample));
+    StopWatch stopWatch = StopWatch.createStarted();
+    Map<String, Map<String, Object>> filters = FilterUtil.buildFilters(queryExample, true);
+    Map<String, Map<String, Object>> ukToRowCache = metaCache.get(tableName);
+
+    if (CollectionUtils.isEmpty(ukToRowCache)) {
+      return Lists.newArrayList();
+    }
+    List<Map<String, Object>> rows = FilterUtil.filterData(ukToRowCache.values(), filters, v -> v);
+    logger.info("[fuzzyByExample] finish, table={}, records={}, cost={}.", tableName, rows.size(),
+        stopWatch.getTime());
+    return rows;
+  }
+
+
+  @Override
+  public long deleteByExample(String tableName, QueryExample queryExample) {
+    logger.info("[deleteByExample] start, table={}, queryExample={}.", tableName,
+        J.toJson(queryExample));
+    StopWatch stopWatch = StopWatch.createStarted();
+    Map<String, Map<String, Object>> filters = FilterUtil.buildFilters(queryExample, false);
+    List<Map<String, Object>> metaDatas = queryByTable(tableName);
+    if (CollectionUtils.isEmpty(metaDatas)) {
+      return 0;
+    }
+    List<String> uks = FilterUtil.filterData(metaDatas, filters, map -> map.get("_uk").toString());
+    if (CollectionUtils.isEmpty(uks)) {
+      return 0;
+    }
+    batchDeleteByPk(tableName, uks);
+    // 输出结果信息
+    logger.info("[deleteByExample] finish, table={}, deleteCount={}, cost={}.", tableName,
+        uks.size(), stopWatch.getTime());
+    return uks.size();
+  }
+
+  @Override
+  public long deleteByRowMap(String tableName, List<Map<String, Object>> rows) {
+    logger.info("[deleteByRowMap] start, table={}, default_pks={}.", tableName, rows.size());
+    if (CollectionUtils.isEmpty(rows))
+      return 0;
+
+    List<String> uks = getUks(tableName, rows);
+    if (CollectionUtils.isEmpty(uks)) {
+      logger.info("[deleteByRowMap] finish, table={}, uks is null.", tableName);
+      return 0;
+    }
+    return batchDeleteByPk(tableName, uks);
+  }
+
+  @Override
+  public long batchDeleteByPk(String tableName, List<String> default_pks) {
+    logger.info("[batchDeleteByPk] start, table={}, default_pks={}.", tableName,
+        default_pks.size());
+
+    if (CollectionUtils.isEmpty(default_pks)) {
+      return 0;
+    }
+    StopWatch stopWatch = StopWatch.createStarted();
+    Integer count = metaDataMapper.softDeleteByUks(tableName, default_pks, new Date());
+    logger.info("[batchDeleteByPk] finish, table={}, deleteCount={}, cost={}, deleteUks:{}",
+        tableName, count, stopWatch.getTime(), default_pks);
+    return count;
+  }
+}

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/grpc/DataServiceGrpcImpl.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/grpc/DataServiceGrpcImpl.java
@@ -4,30 +4,24 @@
 package io.holoinsight.server.meta.core.service.grpc;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import javax.annotation.PostConstruct;
-
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.reflect.TypeToken;
 import io.grpc.stub.StreamObserver;
+import io.holoinsight.server.common.J;
+import io.holoinsight.server.common.Pair;
 import io.holoinsight.server.meta.common.model.QueryExample;
 import io.holoinsight.server.meta.common.util.ConstPool;
 import io.holoinsight.server.meta.common.util.RetryPolicy;
 import io.holoinsight.server.meta.core.service.DBCoreService;
-import io.holoinsight.server.meta.core.service.MongoDataCoreService;
-
-import io.holoinsight.server.meta.proto.data.QueryDataByTableRowsRequest;
-import org.apache.commons.lang3.time.StopWatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-
 import io.holoinsight.server.meta.proto.data.BatchDeleteByPkRequest;
 import io.holoinsight.server.meta.proto.data.DataBaseResponse;
 import io.holoinsight.server.meta.proto.data.DataHello;
@@ -37,11 +31,15 @@ import io.holoinsight.server.meta.proto.data.InsertOrUpdateRequest;
 import io.holoinsight.server.meta.proto.data.QueryDataByExampleRequest;
 import io.holoinsight.server.meta.proto.data.QueryDataByPksRequest;
 import io.holoinsight.server.meta.proto.data.QueryDataByTableRequest;
+import io.holoinsight.server.meta.proto.data.QueryDataByTableRowsRequest;
 import io.holoinsight.server.meta.proto.data.QueryDataResponse;
-import io.holoinsight.server.meta.proto.data.UpdateDataByExampleRequest;
-import io.holoinsight.server.common.J;
-import io.holoinsight.server.common.Pair;
-import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.time.StopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 /**
  * @author jsy1001de
@@ -51,15 +49,23 @@ import com.google.gson.reflect.TypeToken;
 public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
   private static final Logger logger = LoggerFactory.getLogger(DataServiceGrpcImpl.class);
   @Autowired
-  private MongoDataCoreService mongoDataCoreService;
-  @Value("${holoinsight.meta.db_data_mode}")
-  private String db_data_mode;
-  private Map<String, DBCoreService> instanceMap = new HashMap<>();
+  @Qualifier("mongoDataCoreService")
+  private DBCoreService mongoDataCoreService;
 
-  @PostConstruct
-  public void init() {
-    instanceMap.put("mongodb", mongoDataCoreService);
-  }
+  @Autowired
+  @Qualifier("sqlDataCoreService")
+  private DBCoreService sqlDataCoreService;
+
+  @Value("${holoinsight.meta.writeMysql.enabled:true}")
+  private boolean writeMysqlEnable;
+
+  @Value("${holoinsight.meta.readMysql.enabled:false}")
+  private boolean readMysqlEnable;
+
+  private ThreadPoolExecutor writeMysqlExecutor = new ThreadPoolExecutor(3, 3, 0, TimeUnit.MINUTES, //
+      new ArrayBlockingQueue<>(65536), //
+      new ThreadFactoryBuilder().setNameFormat("meta-mysql-%d").build(), //
+      new ThreadPoolExecutor.AbortPolicy());
 
   @Override
   public void insertOrUpdate(InsertOrUpdateRequest request,
@@ -73,7 +79,10 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     DataBaseResponse.Builder builder = DataBaseResponse.newBuilder();
     try {
       Pair<Integer, Integer> insertOrUpdate = tryUntilSuccess(
-          () -> getCurrentService().insertOrUpdate(tableName, rows), "insertOrUpdate", 0);
+          () -> mongoDataCoreService.insertOrUpdate(tableName, rows), "insertOrUpdate", 0);
+      if (writeMysqlEnable) {
+        writeMysqlExecutor.execute(() -> sqlDataCoreService.insertOrUpdate(tableName, rows));
+      }
       builder.setSuccess(true).setRowsJson(String.format("insertCount: %s, updateCount: %s",
           insertOrUpdate.left(), insertOrUpdate.right()));
       logger.info("DimWriterGrpcBackend,insert,Y,{},{},{},{},{},{},", stopWatch.getTime(),
@@ -96,9 +105,10 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     String tableName = request.getTableName();
     List<String> pkVals =
         J.fromJson(request.getPkValsJson(), new TypeToken<List<String>>() {}.getType());
+    DBCoreService coreService = getDbCoreService();
     stopWatch.start();
-    List<Map<String, Object>> rows = tryUntilSuccess(
-        () -> getCurrentService().queryByPks(tableName, pkVals), "queryDataByPks", 0);
+    List<Map<String, Object>> rows =
+        tryUntilSuccess(() -> coreService.queryByPks(tableName, pkVals), "queryDataByPks", 0);
     stopWatch.stop();
     try {
       logger.info("DimWriterGrpcBackend,queryDataByPks,Y,{},{},{},{},{},{},", stopWatch.getTime(),
@@ -116,14 +126,25 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     o.onCompleted();
   }
 
+  private DBCoreService getDbCoreService() {
+    DBCoreService coreService;
+    if (readMysqlEnable) {
+      coreService = sqlDataCoreService;
+    } else {
+      coreService = mongoDataCoreService;
+    }
+    return coreService;
+  }
+
   @Override
   public void queryDataByTableStream(QueryDataByTableRequest request,
       io.grpc.stub.StreamObserver<QueryDataResponse> o) {
     StopWatch stopWatch = StopWatch.createStarted();
     String tableName = request.getTableName();
     List<Map<String, Object>> rows;
+    DBCoreService coreService = getDbCoreService();
     try {
-      rows = tryUntilSuccess(() -> getCurrentService().queryByTable(tableName), "queryByTable", 0);
+      rows = tryUntilSuccess(() -> coreService.queryByTable(tableName), "queryByTable", 0);
       Iterator<Map<String, Object>> it = rows.iterator();
       int total = 0;
       int count = 0;
@@ -164,8 +185,8 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     String pkRows = request.getPkRows();
     List<String> rowVals = J.toList(pkRows);
     try {
-      rows = tryUntilSuccess(() -> getCurrentService().queryByTable(tableName, rowVals),
-          "queryByTable", 0);
+      DBCoreService coreService = getDbCoreService();
+      rows = tryUntilSuccess(() -> coreService.queryByTable(tableName, rowVals), "queryByTable", 0);
       Iterator<Map<String, Object>> it = rows.iterator();
       int total = 0;
       int count = 0;
@@ -205,9 +226,9 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     List<String> pkVals = J.toList(pkValsJson);
     DataBaseResponse.Builder builder = DataBaseResponse.newBuilder();
     try {
-      Long deleteCount =
-          tryUntilSuccess(() -> getCurrentService().batchDeleteByPk(request.getTableName(), pkVals),
-              "batchDeleteByPk", 0);
+      DBCoreService coreService = getDbCoreService();
+      Long deleteCount = tryUntilSuccess(
+          () -> coreService.batchDeleteByPk(request.getTableName(), pkVals), "batchDeleteByPk", 0);
       logger.info("DimWriterGrpcBackend,batchDeleteByPk,Y,{},{},{},{},{},{},{},",
           stopWatch.getTime(), request.getTableName(), pkVals.size(), 0, request.getFromApp(),
           request.getFromIp(), deleteCount);
@@ -232,8 +253,9 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     QueryExample example = J.json2Bean(request.getExampleJson(), QueryExample.class);
     DataBaseResponse.Builder builder = DataBaseResponse.newBuilder();
     try {
-      Long deleteCount = tryUntilSuccess(
-          () -> getCurrentService().deleteByExample(tableName, example), "deleteByExample", 0);
+      DBCoreService coreService = getDbCoreService();
+      Long deleteCount = tryUntilSuccess(() -> coreService.deleteByExample(tableName, example),
+          "deleteByExample", 0);
       logger.info("DimWriterGrpcBackend,deleteByExample,Y,{},{},{},{},{},{},{},",
           stopWatch.getTime(), tableName, 0, 0, request.getFromApp(), request.getFromIp(),
           deleteCount);
@@ -259,8 +281,9 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
         (new TypeToken<List<Map<String, Object>>>() {}).getType());
     DataBaseResponse.Builder builder = DataBaseResponse.newBuilder();
     try {
-      Long deleteCount = tryUntilSuccess(
-          () -> getCurrentService().deleteByRowMap(tableName, example), "deleteByRowMap", 0);
+      DBCoreService coreService = getDbCoreService();
+      Long deleteCount = tryUntilSuccess(() -> coreService.deleteByRowMap(tableName, example),
+          "deleteByRowMap", 0);
       logger.info("DimWriterGrpcBackend,deleteByRowMap,Y,{},{},{},{},{},{},{},",
           stopWatch.getTime(), tableName, 0, 0, request.getFromApp(), request.getFromIp(),
           deleteCount);
@@ -268,31 +291,6 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     } catch (Exception e) {
       logger.error("DimWriterGrpcBackend,deleteByRowMap,N,{},{},{},{},{},{},{},",
           stopWatch.getTime(), tableName, exampleJson, 0, request.getFromApp(), request.getFromIp(),
-          e.getMessage(), e);
-      builder.setSuccess(false);
-      builder.setErrMsg(e.getMessage());
-    }
-    o.onNext(builder.build());
-    o.onCompleted();
-  }
-
-  @Override
-  public void updateByExample(UpdateDataByExampleRequest request,
-      io.grpc.stub.StreamObserver<DataBaseResponse> o) {
-    StopWatch stopWatch = StopWatch.createStarted();
-    String tableName = request.getTableName();
-    QueryExample example = J.json2Bean(request.getExampleJson(), QueryExample.class);
-    Map<String, Object> row = J.toMap(request.getRowJson());
-    DataBaseResponse.Builder builder = DataBaseResponse.newBuilder();
-    try {
-      tryUntilSuccess(() -> getCurrentService().updateByExample(tableName, example, row),
-          "updateByExample", 0);
-      logger.info("DimWriterGrpcBackend,updateByExample,Y,{},{},{},{},{},{},", stopWatch.getTime(),
-          tableName, 0, 0, request.getFromApp(), request.getFromIp());
-      builder.setSuccess(true);
-    } catch (Exception e) {
-      logger.error("DimWriterGrpcBackend,updateByExample,N,{},{},{},{},{},{},{},",
-          stopWatch.getTime(), tableName, 0, 0, request.getFromApp(), request.getFromIp(),
           e.getMessage(), e);
       builder.setSuccess(false);
       builder.setErrMsg(e.getMessage());
@@ -311,8 +309,9 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     List<Map<String, Object>> rows;
     QueryDataResponse.Builder builder = QueryDataResponse.newBuilder();
     try {
-      rows = tryUntilSuccess(() -> getCurrentService().queryByExample(tableName, example),
-          "queryByExample", 0);
+      DBCoreService coreService = getDbCoreService();
+      rows = tryUntilSuccess(() -> coreService.queryByExample(tableName, example), "queryByExample",
+          0);
       logger.info("DimWriterGrpcBackend,queryByExample,Y,{},{},{},{},{},{},", stopWatch.getTime(),
           tableName, 0, rows.size(), request.getFromApp(), request.getFromIp());
       builder.setSuccess(true);
@@ -338,8 +337,9 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     List<Map<String, Object>> rows;
     QueryDataResponse.Builder builder = QueryDataResponse.newBuilder();
     try {
-      rows = tryUntilSuccess(() -> getCurrentService().fuzzyByExample(tableName, example),
-          "fuzzyByExample", 0);
+      DBCoreService coreService = getDbCoreService();
+      rows = tryUntilSuccess(() -> coreService.fuzzyByExample(tableName, example), "fuzzyByExample",
+          0);
       logger.info("DimWriterGrpcBackend,fuzzyByExample,Y,{},{},{},{},{},{},", stopWatch.getTime(),
           tableName, 0, rows.size(), request.getFromApp(), request.getFromIp());
       builder.setSuccess(true);
@@ -364,7 +364,8 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     QueryExample example = J.json2Bean(exampleJson, QueryExample.class);
     List<Map<String, Object>> rows;
     try {
-      rows = tryUntilSuccess(() -> getCurrentService().queryByExample(tableName, example),
+      DBCoreService coreService = getDbCoreService();
+      rows = tryUntilSuccess(() -> coreService.queryByExample(tableName, example),
           "queryByExampleStream", 0);
       Iterator<Map<String, Object>> it = rows.iterator();
       int count = 0;
@@ -441,7 +442,4 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
     }
   }
 
-  public DBCoreService getCurrentService() {
-    return instanceMap.getOrDefault(db_data_mode, mongoDataCoreService);
-  }
 }

--- a/server/meta/meta-dal/pom.xml
+++ b/server/meta/meta-dal/pom.xml
@@ -23,6 +23,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.mybatis</groupId>
+			<artifactId>mybatis</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/server/meta/meta-dal/src/main/java/io/holoinsight/server/meta/dal/service/mapper/MetaDataMapper.java
+++ b/server/meta/meta-dal/src/main/java/io/holoinsight/server/meta/dal/service/mapper/MetaDataMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.meta.dal.service.mapper;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import io.holoinsight.server.meta.dal.service.model.MetaData;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author ljw
+ * @Description MetaDataMapper
+ * @date 2023/4/24
+ */
+@Mapper
+@Repository
+public interface MetaDataMapper {
+
+  void batchInsertOrUpdate(List<MetaData> metaDataList);
+
+  List<MetaData> selectByUks(@Param("tableName") String tableName,
+      @Param("pkList") Collection<String> pkList);
+
+  List<MetaData> selectByExample(@Param("conditions") Map<String, Object> conditions,
+      @Param("offset") int offset, @Param("limit") int limit);
+
+  Integer softDeleteByUks(@Param("tableName") String tableName,
+      @Param("pkList") Collection<String> pkList, @Param("gmtModified") Date gmtModified);
+
+  void updateByUk(@Param("tableName") String tableName, @Param("item") MetaData item);
+
+  List<MetaData> queryChangedMeta(@Param("start") Date start, @Param("end") Date end,
+      @Param("containDeleted") Boolean containDeleted, @Param("offset") int offset,
+      @Param("limit") int limit);
+}

--- a/server/meta/meta-dal/src/main/java/io/holoinsight/server/meta/dal/service/model/MetaData.java
+++ b/server/meta/meta-dal/src/main/java/io/holoinsight/server/meta/dal/service/model/MetaData.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.meta.dal.service.model;
+
+import java.util.Date;
+
+import lombok.Data;
+
+/**
+ * @author ljw
+ * @Description meta data
+ * @date 2023/4/24
+ */
+@Data
+public class MetaData {
+
+  private Long id;
+
+  private Date gmtCreate;
+
+  private Date gmtModified;
+
+  private String tableName;
+
+  private String uk;
+
+  private String json;
+
+  private String annotations;
+
+  private Integer deleted;
+
+}

--- a/server/meta/meta-dal/src/main/resources/mybatis/mybatis-config.xml
+++ b/server/meta/meta-dal/src/main/resources/mybatis/mybatis-config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+	<settings>
+		<setting name="logImpl" value="SLF4J"/>
+		<setting name="mapUnderscoreToCamelCase" value="true"/>
+	</settings>
+	<plugins>
+		<plugin interceptor="com.github.pagehelper.PageInterceptor">
+			<property name="helperDialect" value="mysql"/>
+		</plugin>
+	</plugins>
+</configuration>

--- a/server/meta/meta-dal/src/main/resources/sqlmap/MetaDataMapper.xml
+++ b/server/meta/meta-dal/src/main/resources/sqlmap/MetaDataMapper.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.holoinsight.server.meta.dal.service.mapper.MetaDataMapper">
+
+  <resultMap id="BaseResultMap" type="io.holoinsight.server.meta.dal.service.model.MetaData">
+    <id column="id" jdbcType="BIGINT" property="id" />
+    <result column="gmt_create" jdbcType="TIMESTAMP" property="gmtCreate" />
+    <result column="gmt_modified" jdbcType="TIMESTAMP" property="gmtModified" />
+    <result column="uk" jdbcType="VARCHAR" property="uk" />
+    <result column="table_name" jdbcType="VARCHAR" property="tableName" />
+    <result column="json" jdbcType="VARCHAR" property="json" />
+    <result column="annotations" jdbcType="VARCHAR" property="annotations" />
+    <result column="deleted" jdbcType="INTEGER" property="deleted" />
+  </resultMap>
+
+  <insert id="batchInsertOrUpdate">
+    insert into meta_dim_data(
+    table_name,
+    uk,
+    json,
+    annotations,
+    deleted,
+    gmt_create,
+    gmt_modified
+    )
+    values
+    <foreach collection="metaDataList" item="item" index="index" separator=",">
+    (
+     #{item.tableName},
+     #{item.uk},
+     #{item.json},
+     #{item.annotations},
+     #{item.deleted},
+     #{item.gmtCreate},
+     #{item.gmtModified}
+     )
+    </foreach>
+    ON DUPLICATE KEY UPDATE
+      json = VALUES(json),
+      annotations = VALUES(annotations),
+      deleted = VALUES(deleted),
+      gmt_modified = VALUES(gmt_modified)
+  </insert>
+
+  <update id="updateByUk">
+      update meta_dim_data
+      <set>
+        json = #{item.json}, annotations = #{item.annotations}, gmt_modified = #{item.gmtModified}
+      </set>
+       where table_name = #{tableName} and uk = #{item.uk} and deleted = 0
+  </update>
+
+  <update id="softDeleteByUks">
+    update meta_dim_data set deleted = 1, gmt_modified = #{gmtModified}
+    <where>
+      table_name = #{tableName}
+    </where>
+    <if test="pkList != null and pkList.size() > 0">
+      and uk in
+       <foreach collection="pkList" item="item" separator="," open="(" close=")">
+         #{item}
+       </foreach>
+    </if>
+  </update>
+
+  <select id="selectByUks" resultMap="BaseResultMap">
+    select * from meta_dim_data
+    where
+      table_name = #{tableName}
+    <if test="pkList != null and pkList.size() > 0">
+      AND uk in
+      <foreach collection="pkList" item="item" separator="," open="(" close=")">
+        #{item}
+      </foreach>
+    </if>
+     AND deleted = 0
+  </select>
+
+  <select id="selectByExample" resultMap="BaseResultMap">
+    select * from meta_dim_data
+    <where>
+      <if test="conditions != null and conditions.size() > 0">
+        <foreach collection="conditions" item="v" index="k">
+         and ${k} = #{v}
+        </foreach>
+      </if>
+    </where>
+    limit #{offset},#{limit}
+  </select>
+
+  <select id="queryChangedMeta" resultType="io.holoinsight.server.meta.dal.service.model.MetaData">
+    SELECT
+      table_name AS tableName,
+      uk,
+      json,
+      deleted
+    FROM meta_dim_data
+    where
+        gmt_modified >= #{start}
+        and  <![CDATA[gmt_modified <= #{end}]]>
+        <if test="!containDeleted">
+          and deleted = 0
+        </if>
+        limit #{offset},#{limit}
+  </select>
+
+</mapper>

--- a/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/DataClientService.java
+++ b/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/DataClientService.java
@@ -25,8 +25,6 @@ public interface DataClientService {
 
   void deleteByExample(String tableName, QueryExample example);
 
-  void updateByExample(String tableName, QueryExample example, Map<String, Object> row);
-
   List<Map<String, Object>> queryByExample(String tableName, QueryExample example);
 
   List<Map<String, Object>> fuzzyByExample(String tableName, QueryExample example);

--- a/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/DimCookie.java
+++ b/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/DimCookie.java
@@ -210,22 +210,6 @@ public class DimCookie implements DataClientService, AgentHeartBeatService, Seri
   }
 
   @Override
-  public void updateByExample(String tableName, QueryExample example, Map<String, Object> row) {
-    String exampleJson = J.toJson(example);
-    UpdateDataByExampleRequest updateDataByExampleRequest =
-        UpdateDataByExampleRequest.newBuilder().setTableName(tableName).setExampleJson(exampleJson)
-            .setFromApp(clientService.getCurrentApp()).setRowJson(J.toJson(row))
-            .setFromIp(clientService.getLocalIp()).build();
-    DataBaseResponse dataBaseResponse = DataServiceGrpc.newBlockingStub(channel)
-        .withDeadlineAfter(ConstPool.GRPC_WITH_DEADLINE_AFTER_MS_1, TimeUnit.MILLISECONDS)
-        .updateByExample(updateDataByExampleRequest);
-    if (!dataBaseResponse.getSuccess()) {
-      throw new ClientException("execute updateByExample for dimTable[%s] fail : %s. ", tableName,
-          dataBaseResponse.getErrMsg());
-    }
-  }
-
-  @Override
   public List<Map<String, Object>> queryByExample(String tableName, QueryExample example) {
 
     String exampleJson = J.toJson(example);

--- a/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/impl/DataClientServiceImpl.java
+++ b/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/impl/DataClientServiceImpl.java
@@ -60,11 +60,6 @@ public class DataClientServiceImpl extends AbstractCacheInteractService
   }
 
   @Override
-  public void updateByExample(String tableName, QueryExample example, Map<String, Object> row) {
-    pickOneCookie().updateByExample(tableName, example, row);
-  }
-
-  @Override
   public List<Map<String, Object>> queryByExample(String tableName, QueryExample example) {
     return pickOneCookie().queryByExample(tableName, example);
   }

--- a/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/impl/LocalDataClientService.java
+++ b/server/meta/meta-facade/src/main/java/io/holoinsight/server/meta/facade/service/impl/LocalDataClientService.java
@@ -42,11 +42,6 @@ public class LocalDataClientService implements DataClientService {
   }
 
   @Override
-  public void updateByExample(String tableName, QueryExample example, Map<String, Object> row) {
-
-  }
-
-  @Override
   public List<Map<String, Object>> queryByExample(String tableName, QueryExample example) {
     return null;
   }

--- a/server/meta/meta-proto/src/main/proto/DataService.proto
+++ b/server/meta/meta-proto/src/main/proto/DataService.proto
@@ -12,21 +12,6 @@ service DataService {
   rpc insertOrUpdate (InsertOrUpdateRequest) returns (DataBaseResponse) {
   }
 
-  rpc insert (InsertOrUpdateRequest) returns (DataBaseResponse) {
-  }
-
-  rpc update (InsertOrUpdateRequest) returns (DataBaseResponse) {
-  }
-
-  rpc queryDataByTable (QueryDataByTableRequest) returns (QueryDataResponse) {
-  }
-
-  rpc queryDataByPk (QueryDataByPkRequest) returns (QueryOneDataResponse) {
-  }
-
-  rpc queryDataByPks (QueryDataByPksRequest) returns (QueryDataResponse) {
-  }
-
   rpc queryDataByTableStream (QueryDataByTableRequest) returns (stream QueryDataResponse) {
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #452 

# Rationale for this change
 
Support for using MySQL to store metadata

# What changes are included in this PR?
To verify the ability to write metadata to MySQL, it will be temporarily validated by writing to both MongoDB and MySQL simultaneously. 

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
local test
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
