### PR TITLE
feat: query trace with tenant and time range

### DIFF
--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanEsStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/SpanEsStorage.java
@@ -41,13 +41,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static java.util.Objects.nonNull;
 
@@ -108,11 +102,14 @@ public class SpanEsStorage extends RecordEsStorage<SpanDO> implements SpanStorag
   }
 
   @Override
-  public Trace queryTrace(String traceId) throws IOException {
+  public Trace queryTrace(String tenant, long start, long end, String traceId) throws IOException {
     Trace trace = new Trace();
-    QueryBuilder queryBuilder = new TermQueryBuilder(SpanDO.TRACE_ID, traceId);
+
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-    searchSourceBuilder.query(queryBuilder);
+
+    searchSourceBuilder.query(buildQuery(tenant, null, null, null,
+        Collections.singletonList(traceId), 0, 0, null, start, end, null, this.timeSeriesField()));
+
     searchSourceBuilder.size(SPAN_QUERY_MAX_SIZE);
     SearchRequest searchRequest =
         new SearchRequest(new String[] {SpanDO.INDEX_NAME}, searchSourceBuilder);

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/storage/SpanStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/storage/SpanStorage.java
@@ -25,5 +25,6 @@ public interface SpanStorage extends WritableStorage<SpanDO>, ReadableStorage {
       final QueryOrder queryOrder, final Pagination paging, final long start, final long end,
       final List<Tag> tags) throws Exception;
 
-  Trace queryTrace(final String traceId) throws Exception;
+  Trace queryTrace(final String tenant, final long start, final long end, final String traceId)
+      throws Exception;
 }

--- a/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/TraceService.java
+++ b/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/TraceService.java
@@ -22,7 +22,8 @@ public interface TraceService {
       final QueryOrder queryOrder, final Pagination paging, final long start, final long end,
       final List<Tag> tags) throws Exception;
 
-  Trace queryTrace(final String traceId) throws Exception;
+  Trace queryTrace(final String tenant, final long start, final long end, final String traceId)
+      throws Exception;
 
   void insertSpans(final List<SpanDO> spans) throws Exception;
 

--- a/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/TraceServiceImpl.java
+++ b/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/TraceServiceImpl.java
@@ -37,8 +37,8 @@ public class TraceServiceImpl implements TraceService {
   }
 
   @Override
-  public Trace queryTrace(String traceId) throws Exception {
-    return spanStorage.queryTrace(traceId);
+  public Trace queryTrace(String tenant, long start, long end, String traceId) throws Exception {
+    return spanStorage.queryTrace(tenant, start, end, traceId);
   }
 
   @Override

--- a/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/impl/TraceApiController.java
+++ b/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/impl/TraceApiController.java
@@ -35,12 +35,14 @@ public class TraceApiController implements TraceApi {
 
     if (CollectionUtils.isNotEmpty(request.getTraceIds())) {
       traceIds = request.getTraceIds();
-    } else if (nonNull(request.getDuration())) {
+    }
+    if (nonNull(request.getDuration())) {
       start = request.getDuration().getStart();
       end = request.getDuration().getEnd();
-    } else {
+    }
+    if (CollectionUtils.isEmpty(traceIds) && start == 0 && end == 0) {
       throw new IllegalArgumentException(
-          "The condition must contains either queryDuration or traceId.");
+          "The condition must contains either queryDuration or traceIds.");
     }
 
     int minDuration = request.getMinTraceDuration();
@@ -58,7 +60,19 @@ public class TraceApiController implements TraceApi {
 
   @Override
   public ResponseEntity<Trace> queryTrace(QueryTraceRequest request) throws Exception {
-    Trace trace = traceService.queryTrace(request.getTraceIds().get(0));
+
+
+    if (CollectionUtils.isEmpty(request.getTraceIds())) {
+      throw new IllegalArgumentException("The condition must contains traceIds.");
+    }
+    List<String> traceIds = request.getTraceIds();
+    long start = 0;
+    long end = 0;
+    if (nonNull(request.getDuration())) {
+      start = request.getDuration().getStart();
+      end = request.getDuration().getEnd();
+    }
+    Trace trace = traceService.queryTrace(request.getTenant(), start, end, traceIds.get(0));
     return ResponseEntity.ok(trace);
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
This PR is to optimize the implementation of `queryTrace` API: support the transfer of conditions such as tenant and time interval that can be used for query pruning to the underlying storage engine.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Functions related to `queryTrace` can pass in three additional fields: `tenant`, `start`, `end`, and build query requests for the underlying storage engine accordingly.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Users can get better response performance when querying a single trace.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI and E2E tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
