### PR TITLE
feat: limit queue size

### DIFF
--- a/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/ApmMetricMaterializer.java
+++ b/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/ApmMetricMaterializer.java
@@ -61,7 +61,7 @@ public class ApmMetricMaterializer {
       new BasicThreadFactory.Builder().namingPattern("apm-materialize-scheduler-%d").build());
 
   private static final ThreadPoolExecutor EXECUTOR =
-      new ThreadPoolExecutor(4, 4, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
+      new ThreadPoolExecutor(4, 4, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(4096),
           new BasicThreadFactory.Builder().namingPattern("apm-materialize-executor-%d").build());
 
   @PostConstruct


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Limit the queue length of the APM indicator materialized thread pool to avoid HoloInsight FGC when the performance of the downstream engine deteriorates.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Limit the queue size of ApmMaterializer to 4096.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI and E2E tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
