### PR TITLE
feat: metadata module supports custom indexes

### DIFF
--- a/server/meta/meta-common/src/main/java/io/holoinsight/server/meta/common/util/ConstModel.java
+++ b/server/meta/meta-common/src/main/java/io/holoinsight/server/meta/common/util/ConstModel.java
@@ -25,5 +25,7 @@ public class ConstModel {
   public static final String READ_MYSQL_ENABLE = "readMysqlEnable";
   public static final String WRITE_MYSQL_ENABLE = "writeMysqlEnable";
   public static final String META_CONFIG = "meta_config";
+  public static final String ANNOTATIONS = "annotations";
+  public static final String META_INDEX_CONFIG = "meta_index_config";
 
 }

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
@@ -33,8 +33,9 @@ public class MetaServiceConfiguration {
 
   @Bean("sqlDataCoreService")
   // @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mysql")
-  public DBCoreService SqlDataCoreService(MetaDataMapper metaDataMapper) {
-    return new SqlDataCoreService(metaDataMapper);
+  public DBCoreService SqlDataCoreService(MetaDataMapper metaDataMapper,
+      SuperCacheService superCacheService) {
+    return new SqlDataCoreService(metaDataMapper, superCacheService);
   }
 
   @Bean

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/common/FilterUtil.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/common/FilterUtil.java
@@ -132,4 +132,13 @@ public class FilterUtil {
     }
   }
 
+  public static List<String> genCartesianStrList(List<List<String>> wordsList) {
+    List<String> cartesianStrList = wordsList.get(0);
+    for (int i = 1; i < wordsList.size(); i++) {
+      List<String> secondList = wordsList.get(i);
+      cartesianStrList = cartesianStrList.stream()
+          .flatMap(s1 -> secondList.stream().map(s2 -> s1 + ":" + s2)).collect(Collectors.toList());
+    }
+    return cartesianStrList;
+  }
 }

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
@@ -416,13 +416,15 @@ public class SqlDataCoreService extends AbstractDataCoreService {
       QueryExample queryExample, Map<String, Map<String, Object>> ukToRowCache) {
     Map<String, Object> params = queryExample.getParams();
     if (params.containsKey(ConstModel.default_pk)) {
+      logger.info("[META-CACHE] hit index: [{}], table={}, params:{}", ConstModel.default_pk, tableName, params);
       return getMetaDataFromUkCache(ukToRowCache, params);
     }
     List<String> indexKeys = getMatchedIndex(tableName, params);
     if (!CollectionUtils.isEmpty(indexKeys)) {
+      logger.info("[META-CACHE] hit index: {}, table={}, params:{}", indexKeys, tableName, params);
       return getMetaDataFromIndexCache(tableName, ukToRowCache, params, indexKeys);
     }
-    logger.info("[META-CACHE] miss index, params:{}", params);
+    logger.info("[META-CACHE] miss index, table={}, params:{}", tableName, params);
     return ukToRowCache.values();
   }
 

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
@@ -416,7 +416,8 @@ public class SqlDataCoreService extends AbstractDataCoreService {
       QueryExample queryExample, Map<String, Map<String, Object>> ukToRowCache) {
     Map<String, Object> params = queryExample.getParams();
     if (params.containsKey(ConstModel.default_pk)) {
-      logger.info("[META-CACHE] hit index: [{}], table={}, params:{}", ConstModel.default_pk, tableName, params);
+      logger.info("[META-CACHE] hit index: [{}], table={}, params:{}", ConstModel.default_pk,
+          tableName, params);
       return getMetaDataFromUkCache(ukToRowCache, params);
     }
     List<String> indexKeys = getMatchedIndex(tableName, params);
@@ -568,8 +569,8 @@ public class SqlDataCoreService extends AbstractDataCoreService {
     }
     StopWatch stopWatch = StopWatch.createStarted();
     Integer count = metaDataMapper.softDeleteByUks(tableName, default_pks, new Date());
-    logger.info("[batchDeleteByPk] finish, table={}, deleteCount={}, cost={}",
-        tableName, count, stopWatch.getTime());
+    logger.info("[batchDeleteByPk] finish, table={}, deleteCount={}, cost={}", tableName, count,
+        stopWatch.getTime());
     return count;
   }
 }

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/grpc/DataServiceGrpcImpl.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/grpc/DataServiceGrpcImpl.java
@@ -130,9 +130,7 @@ public class DataServiceGrpcImpl extends DataServiceGrpc.DataServiceImplBase {
 
   private DBCoreService getDbCoreService() {
     DBCoreService coreService;
-    boolean b = readMysqlEnable();
-    logger.info("readMysqlEnable:{}", b);
-    if (b) {
+    if (readMysqlEnable()) {
       coreService = sqlDataCoreService;
     } else {
       coreService = mongoDataCoreService;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #479


# Rationale for this change
 In SQL mode, improve retrieval speed by customizing indexes

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
In SQL mode, the metadata module can insert records into the metadata_dictvalue table to build query indexes as specified by the dict_value field：
INSERT INTO metadata_dictvalue (`type`,`dict_key`,`dict_value`,`dict_value_type`,`dict_desc`,`version`,`creator`,`modifier`,`gmt_create`,`gmt_modified`) VALUES('meta_index_config','table_name','[["app"],["_workspace","_cluster","_type"]]',null,null,1,'admin','admin',NOW(),NOW());
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
local test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
