### PR TITLE
feat: tenant adaptation in alarm query

### DIFF
--- a/server/home/home-boot/src/main/java/io/holoinsight/server/home/bootstrap/HoloinsightHomeConfiguration.java
+++ b/server/home/home-boot/src/main/java/io/holoinsight/server/home/bootstrap/HoloinsightHomeConfiguration.java
@@ -21,6 +21,8 @@ import io.holoinsight.server.home.biz.service.UserinfoVerificationService;
 import io.holoinsight.server.home.biz.service.impl.DefaultEnvironmentServiceImpl;
 import io.holoinsight.server.home.biz.service.impl.DefaultTenantInitServiceImpl;
 import io.holoinsight.server.home.biz.service.impl.UserinfoVerificationServiceImpl;
+import io.holoinsight.server.home.common.service.RequestContextAdapter;
+import io.holoinsight.server.home.common.service.RequestContextAdapterImpl;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -76,5 +78,10 @@ public class HoloinsightHomeConfiguration {
   @Bean
   public UserinfoVerificationService userinfoVerificationService() {
     return new UserinfoVerificationServiceImpl();
+  }
+
+  @Bean
+  public RequestContextAdapter requestContextAdapter() {
+    return new RequestContextAdapterImpl();
   }
 }

--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/QueryClientService.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/QueryClientService.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -42,6 +43,9 @@ public class QueryClientService {
 
   @GrpcClient("queryService")
   private QueryServiceGrpc.QueryServiceBlockingStub queryServiceBlockingStub;
+
+  @Autowired
+  private RequestContextAdapter requestContextAdapter;
 
   public QueryResponse query(QueryProto.QueryRequest request) {
     Debugger.print("QueryService", "query, request: " + J.toJson(request));
@@ -324,8 +328,9 @@ public class QueryClientService {
 
   public QueryProto.QueryResponse queryData(QueryProto.QueryRequest request) {
 
+    QueryProto.QueryRequest queryRequest = this.requestContextAdapter.requestAdapte(request);
     long start = System.currentTimeMillis();
-    QueryProto.QueryResponse response = queryServiceBlockingStub.queryData(request);
+    QueryProto.QueryResponse response = queryServiceBlockingStub.queryData(queryRequest);
     int pointSize = getPointSizeFromResp(response);
     log.info("HOME_QUERY_STAT from[ALERT] invoke[1], cost[{}], pointSize[{}]",
         System.currentTimeMillis() - start, pointSize);
@@ -333,14 +338,15 @@ public class QueryClientService {
   }
 
   public QueryProto.QueryResponse queryTag(QueryProto.QueryRequest request) {
-
-    QueryProto.QueryResponse response = queryServiceBlockingStub.queryTags(request);
+    QueryProto.QueryRequest queryRequest = this.requestContextAdapter.requestAdapte(request);
+    QueryProto.QueryResponse response = queryServiceBlockingStub.queryTags(queryRequest);
     return response;
   }
 
   public QueryProto.QueryResponse queryPqlRange(QueryProto.PqlRangeRequest request) {
+    QueryProto.PqlRangeRequest PqlRangeRequest = this.requestContextAdapter.requestAdapte(request);
     long start = System.currentTimeMillis();
-    QueryProto.QueryResponse response = queryServiceBlockingStub.pqlRangeQuery(request);
+    QueryProto.QueryResponse response = queryServiceBlockingStub.pqlRangeQuery(PqlRangeRequest);
     int pointSize = getPointSizeFromResp(response);
     log.info("HOME_QUERY_STAT from[PQL] invoke[1], cost[{}], pointSize[{}]",
         System.currentTimeMillis() - start, pointSize);

--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapter.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapter.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.common.service;
+
+import io.holoinsight.server.query.grpc.QueryProto;
+
+/**
+ * @author masaimu
+ * @version 2023-06-09 17:30:00
+ */
+public interface RequestContextAdapter {
+
+  QueryProto.QueryRequest requestAdapte(QueryProto.QueryRequest request);
+
+  QueryProto.PqlRangeRequest requestAdapte(QueryProto.PqlRangeRequest request);
+
+}

--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapterImpl.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapterImpl.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.home.common.service;
+
+import io.holoinsight.server.query.grpc.QueryProto;
+
+/**
+ * @author masaimu
+ * @version 2023-06-09 17:31:00
+ */
+public class RequestContextAdapterImpl implements RequestContextAdapter {
+  @Override
+  public QueryProto.QueryRequest requestAdapte(QueryProto.QueryRequest request) {
+    return request;
+  }
+
+  @Override
+  public QueryProto.PqlRangeRequest requestAdapte(QueryProto.PqlRangeRequest request) {
+    return request;
+  }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #487 

# Rationale for this change
 
- Provide the interface that change the query tenant in alert query.

# What changes are included in this PR?

- Add `server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapter.java`

# Are there any user-facing changes?

None.

# How does this change test

None.
