### PR TITLE
feat: tatris scene

### DIFF
--- a/test/scenes/common/base.yaml
+++ b/test/scenes/common/base.yaml
@@ -130,7 +130,7 @@ services:
       retries: 300
       timeout: 10s
   tatris:
-    image: ${tatris_image:-saas-acr-sh-registry.cn-shanghai.cr.aliyuncs.com/holoinsight/tatris:0.1.1}
+    image: ${tatris_image:-tatrisio/tatris:latest}
     ports:
       - 6060
     healthcheck:

--- a/test/scenes/common/base.yaml
+++ b/test/scenes/common/base.yaml
@@ -129,6 +129,15 @@ services:
       interval: 1s
       retries: 300
       timeout: 10s
+  tatris:
+    image: ${tatris_image:-saas-acr-sh-registry.cn-shanghai.cr.aliyuncs.com/holoinsight/tatris:0.1.1}
+    ports:
+      - 6060
+    healthcheck:
+      test: [ "CMD", "timeout", "1", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/6060" ]
+      interval: 1s
+      retries: 300
+      timeout: 10s
   kibana:
     image: ${kibana_image:-kibana:7.16.1}
     environment:

--- a/test/scenes/common/base.yaml
+++ b/test/scenes/common/base.yaml
@@ -131,6 +131,8 @@ services:
       timeout: 10s
   tatris:
     image: ${tatris_image:-tatrisio/tatris:latest}
+    volumes:
+      - /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime:ro
     ports:
       - 6060
     healthcheck:

--- a/test/scenes/scene-default/application.yaml
+++ b/test/scenes/scene-default/application.yaml
@@ -29,12 +29,8 @@ holoinsight:
     database: holoinsight
   storage:
     elasticsearch:
-      enable: false
-      hosts: es
-      port: 9200
-    tatris:
       enable: true
-      host: tatris
+      hosts: tatris
       port: 6060
   security:
     whiteHosts: server

--- a/test/scenes/scene-default/application.yaml
+++ b/test/scenes/scene-default/application.yaml
@@ -29,8 +29,12 @@ holoinsight:
     database: holoinsight
   storage:
     elasticsearch:
-      enable: true
+      enable: false
       hosts: es
       port: 9200
+    tatris:
+      enable: true
+      host: tatris
+      port: 6060
   security:
     whiteHosts: server

--- a/test/scenes/scene-default/docker-compose.yaml
+++ b/test/scenes/scene-default/docker-compose.yaml
@@ -37,6 +37,11 @@ services:
     extends:
       file: ../common/base.yaml
       service: es
+  # tatris
+  tatris:
+    extends:
+      file: ../common/base.yaml
+      service: tatris
   kibana:
     extends:
       file: ../common/base.yaml
@@ -70,6 +75,8 @@ services:
       ceresdb:
         condition: service_healthy
       es:
+        condition: service_healthy
+      tatris:
         condition: service_healthy
     volumes:
     - ./application.yaml:/home/admin/application.yaml:ro


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Use [Tatris](https://github.com/tatris-io/tatris) as the storage engine of APM in test scenes.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. Use [Tatris](https://github.com/tatris-io/tatris) as the storage engine of APM in test scenes.
2. Fix the data type handling exception of `_timestamp` field.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
I have verified that the HoloInsight service can be started normally through `up.sh`.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
