### PR TITLE
feat: remove default configurations related to MongoDB 

### DIFF
--- a/deploy/examples/docker-compose/application.yaml
+++ b/deploy/examples/docker-compose/application.yaml
@@ -4,9 +4,9 @@ spring:
     username: holoinsight
     password: holoinsight
     driver-class-name: com.mysql.cj.jdbc.Driver
-  data:
-    mongodb:
-      uri: mongodb://holoinsight:holoinsight@mongo:27017/holoinsight?keepAlive=true&maxIdleTimeMS=1500000&maxWaitTime=120000&connectTimeout=10000&socketTimeout=10000&socketKeepAlive=true&retryWrites=true
+#  data:
+#    mongodb:
+#      uri: mongodb://holoinsight:holoinsight@mongo:27017/holoinsight?keepAlive=true&maxIdleTimeMS=1500000&maxWaitTime=120000&connectTimeout=10000&socketTimeout=10000&socketKeepAlive=true&retryWrites=true
 
 holoinsight:
   metric:
@@ -16,3 +16,8 @@ holoinsight:
     enabled: false
   meta:
     database: holoinsight
+
+management:
+  health:
+    mongo:
+      enabled: false

--- a/deploy/examples/docker-compose/docker-compose.yaml
+++ b/deploy/examples/docker-compose/docker-compose.yaml
@@ -17,20 +17,20 @@ services:
       interval: 5s
       retries: 300
       timeout: 10s
-  mongo:
-    image: ${mongo_image}
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: holoinsight
-      MONGO_INITDB_ROOT_PASSWORD: holoinsight
-      MONGO_INITDB_DATABASE: holoinsight
-    volumes:
-    - ./init.js:/docker-entrypoint-initdb.d/init.js
-    restart: always
-    healthcheck:
-      test: ["CMD", "timeout", "1", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/27017"]
-      interval: 5s
-      retries: 300
-      timeout: 10s
+#  mongo:
+#    image: ${mongo_image}
+#    environment:
+#      MONGO_INITDB_ROOT_USERNAME: holoinsight
+#      MONGO_INITDB_ROOT_PASSWORD: holoinsight
+#      MONGO_INITDB_DATABASE: holoinsight
+#    volumes:
+#    - ./init.js:/docker-entrypoint-initdb.d/init.js
+#    restart: always
+#    healthcheck:
+#      test: ["CMD", "timeout", "1", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/27017"]
+#      interval: 5s
+#      retries: 300
+#      timeout: 10s
   ceresdb:
     image: ${ceresdb_image}
     volumes:
@@ -69,8 +69,8 @@ services:
     depends_on:
       mysql-data-init:
         condition: service_completed_successfully
-      mongo:
-        condition: service_healthy
+#      mongo:
+#        condition: service_healthy
       ceresdb:
         condition: service_healthy
     volumes:

--- a/deploy/examples/k8s/base/kustomization.yaml
+++ b/deploy/examples/k8s/base/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - clusterroles.yaml
 - clusterrolebindings.yaml
 - mysql.yaml
-- mongo.yaml
+#- mongo.yaml
 - ceresdb.yaml
 - server.yaml
 - collector.yaml

--- a/deploy/examples/k8s/base/server.yaml
+++ b/deploy/examples/k8s/base/server.yaml
@@ -59,9 +59,6 @@ data:
         username: holoinsight
         password: holoinsight
         driver-class-name: com.mysql.cj.jdbc.Driver
-      data:
-        mongodb:
-          uri: mongodb://holoinsight:holoinsight@mongo:27017/holoinsight?keepAlive=true&maxIdleTimeMS=1500000&maxWaitTime=120000&connectTimeout=10000&socketTimeout=10000&socketKeepAlive=true&retryWrites=true
     holoinsight:
       metric:
         storage:
@@ -75,10 +72,14 @@ data:
                 port: 9090
       meta:
         database: holoinsight
+        db_data_mode: mysql
       flyway:
         enabled: false
-
----
+    management:
+      health:
+        mongo:
+          enabled: false    
+        ---
 apiVersion: v1
 kind: Service
 metadata:

--- a/server/all-in-one/all-in-one-bootstrap/src/main/resources/config/application.yaml
+++ b/server/all-in-one/all-in-one-bootstrap/src/main/resources/config/application.yaml
@@ -59,7 +59,7 @@ holoinsight:
   meta:
     database: holoinsight
     domain: 127.0.0.1
-    db_data_mode: mongodb
+    db_data_mode: mysql
     mongodb_config:
       key-need-convert: false
   registry:
@@ -83,6 +83,8 @@ management:
   endpoint:
     health:
       show-details: always
+      mongo:
+        enabled: false
 
 crypto:
   client:

--- a/server/meta/meta-boot/src/main/java/io/holoinsight/server/meta/bootstrap/HoloinsightMetaConfiguration.java
+++ b/server/meta/meta-boot/src/main/java/io/holoinsight/server/meta/bootstrap/HoloinsightMetaConfiguration.java
@@ -5,9 +5,7 @@ package io.holoinsight.server.meta.bootstrap;
 
 import io.holoinsight.server.common.springboot.ConditionalOnRole;
 
-import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
@@ -19,6 +17,5 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @ComponentScan({"io.holoinsight.server.meta"})
 @EnableScheduling
 @ConditionalOnRole("meta")
-@Import(MongoAutoConfiguration.class)
 public class HoloinsightMetaConfiguration {
 }

--- a/server/meta/meta-boot/src/main/java/io/holoinsight/server/meta/bootstrap/MetaMongoDBConfig.java
+++ b/server/meta/meta-boot/src/main/java/io/holoinsight/server/meta/bootstrap/MetaMongoDBConfig.java
@@ -9,8 +9,10 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author jsy1001de
@@ -19,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mongodb",
     matchIfMissing = true)
+@Import(MongoAutoConfiguration.class)
 public class MetaMongoDBConfig {
 
   @Value("${spring.data.mongodb.uri}")

--- a/server/meta/meta-common/src/main/java/io/holoinsight/server/meta/common/util/ConstModel.java
+++ b/server/meta/meta-common/src/main/java/io/holoinsight/server/meta/common/util/ConstModel.java
@@ -28,5 +28,6 @@ public class ConstModel {
   public static final String META_CONFIG = "meta_config";
   public static final String ANNOTATIONS = "annotations";
   public static final String META_INDEX_CONFIG = "meta_index_config";
+  public static final String CLEAN_META_DURATION_HOURS = "clean_meta_duration_hours";
 
 }

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
@@ -32,7 +32,7 @@ public class MetaServiceConfiguration {
   }
 
   @Bean("sqlDataCoreService")
-   @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mysql")
+  @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mysql")
   public DBCoreService SqlDataCoreService(MetaDataMapper metaDataMapper,
       SuperCacheService superCacheService) {
     return new SqlDataCoreService(metaDataMapper, superCacheService);

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/MetaServiceConfiguration.java
@@ -32,7 +32,7 @@ public class MetaServiceConfiguration {
   }
 
   @Bean("sqlDataCoreService")
-  // @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mysql")
+   @ConditionalOnProperty(value = "holoinsight.meta.db_data_mode", havingValue = "mysql")
   public DBCoreService SqlDataCoreService(MetaDataMapper metaDataMapper,
       SuperCacheService superCacheService) {
     return new SqlDataCoreService(metaDataMapper, superCacheService);

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
@@ -119,7 +119,7 @@ public class SqlDataCoreService extends AbstractDataCoreService {
             logger.info("[META-SYNC] sync success, size={}, last={}, now={}, cost={}", count, last,
                 now, stopWatch.getTime());
           }
-          if (now - logLast >= LOG_INTERVAL) {
+          if (now - logLast >= LOG_INTERVAL && now / 1000 % 60 <= PERIOD) {
             ukMetaCache.forEach((tableName, metaData) -> {
               logger.info("[META-INFO] ukMetaCache at {}, table={}, index={}, records={}", now,
                   tableName, ConstModel.default_pk,

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/service/SqlDataCoreService.java
@@ -92,9 +92,7 @@ public class SqlDataCoreService extends AbstractDataCoreService {
     sync();
     scheduledExecutor.scheduleAtFixedRate(this::sync, 60 - LocalTime.now().getSecond(), PERIOD,
         TimeUnit.SECONDS);
-    // cleanMeatExecutor.scheduleAtFixedRate(this::cleanMeta, new Random().nextInt(3600),3600,
-    // TimeUnit.SECONDS);
-    cleanMeatExecutor.scheduleAtFixedRate(this::cleanMeta, 60 - LocalTime.now().getSecond(), PERIOD,
+    cleanMeatExecutor.scheduleAtFixedRate(this::cleanMeta, new Random().nextInt(3600), 3600,
         TimeUnit.SECONDS);
   }
 

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/web/controller/AdminController.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/web/controller/AdminController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -27,29 +28,19 @@ import java.util.Map;
 public class AdminController {
 
   @Autowired
-  @Qualifier("mongoDataCoreService")
-  private DBCoreService mongoDataCoreService;
+  private DBCoreService coreService;
 
-  @Autowired
-  @Qualifier("sqlDataCoreService")
-  private DBCoreService sqlDataCoreService;
-
-  @PostMapping("/mongodb/query/{collection}")
+  @PostMapping("/meta/query/{collection}")
   public JsonResult<Object> query(@PathVariable("collection") String collection,
       @RequestBody Map<String, Object> condition) {
     QueryExample queryExample = new QueryExample();
     queryExample.getParams().putAll(condition);
+    if (condition.containsKey("rowKeys")) {
+      Object rowKeys = condition.remove("rowKeys");
+      queryExample.setRowKeys((List)rowKeys);
+    }
     return JsonResult
-        .createSuccessResult(mongoDataCoreService.queryByExample(collection, queryExample));
-  }
-
-  @PostMapping("/mysql/query/{collection}")
-  public JsonResult<Object> mysqlQuery(@PathVariable("collection") String collection,
-      @RequestBody Map<String, Object> condition) {
-    QueryExample queryExample = new QueryExample();
-    queryExample.getParams().putAll(condition);
-    return JsonResult
-        .createSuccessResult(sqlDataCoreService.queryByExample(collection, queryExample));
+        .createSuccessResult(coreService.queryByExample(collection, queryExample));
   }
 
 }

--- a/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/web/controller/AdminController.java
+++ b/server/meta/meta-core/src/main/java/io/holoinsight/server/meta/core/web/controller/AdminController.java
@@ -37,10 +37,9 @@ public class AdminController {
     queryExample.getParams().putAll(condition);
     if (condition.containsKey("rowKeys")) {
       Object rowKeys = condition.remove("rowKeys");
-      queryExample.setRowKeys((List)rowKeys);
+      queryExample.setRowKeys((List) rowKeys);
     }
-    return JsonResult
-        .createSuccessResult(coreService.queryByExample(collection, queryExample));
+    return JsonResult.createSuccessResult(coreService.queryByExample(collection, queryExample));
   }
 
 }

--- a/server/meta/meta-dal/src/main/java/io/holoinsight/server/meta/dal/service/mapper/MetaDataMapper.java
+++ b/server/meta/meta-dal/src/main/java/io/holoinsight/server/meta/dal/service/mapper/MetaDataMapper.java
@@ -35,4 +35,6 @@ public interface MetaDataMapper {
   List<MetaData> queryChangedMeta(@Param("start") Date start, @Param("end") Date end,
       @Param("containDeleted") Boolean containDeleted, @Param("offset") int offset,
       @Param("limit") int limit);
+
+  Integer cleanMetaData(@Param("end") Date end);
 }

--- a/server/meta/meta-dal/src/main/resources/sqlmap/MetaDataMapper.xml
+++ b/server/meta/meta-dal/src/main/resources/sqlmap/MetaDataMapper.xml
@@ -63,7 +63,11 @@
     </if>
   </update>
 
-  <select id="selectByUks" resultMap="BaseResultMap">
+    <delete id="cleanMetaData">
+        delete from meta_dim_data where deleted = 1 and  <![CDATA[gmt_modified <= #{end}]]>
+    </delete>
+
+    <select id="selectByUks" resultMap="BaseResultMap">
     select * from meta_dim_data
     where
       table_name = #{tableName}

--- a/test/scenes/scene-default/application.yaml
+++ b/test/scenes/scene-default/application.yaml
@@ -4,9 +4,9 @@ spring:
     username: holoinsight
     password: holoinsight
     driver-class-name: com.mysql.cj.jdbc.Driver
-  data:
-    mongodb:
-      uri: mongodb://holoinsight:holoinsight@mongo:27017/holoinsight?keepAlive=true&maxIdleTimeMS=1500000&maxWaitTime=120000&connectTimeout=10000&socketTimeout=10000&socketKeepAlive=true&retryWrites=true
+#  data:
+#    mongodb:
+#      uri: mongodb://holoinsight:holoinsight@mongo:27017/holoinsight?keepAlive=true&maxIdleTimeMS=1500000&maxWaitTime=120000&connectTimeout=10000&socketTimeout=10000&socketKeepAlive=true&retryWrites=true
 
 holoinsight:
   roles:
@@ -27,6 +27,7 @@ holoinsight:
     active: trace
   meta:
     database: holoinsight
+    db_data_mode: mysql
   storage:
     elasticsearch:
       enable: true
@@ -34,3 +35,8 @@ holoinsight:
       port: 6060
   security:
     whiteHosts: server
+
+management:
+  health:
+    mongo:
+      enabled: false

--- a/test/scenes/scene-default/docker-compose.yaml
+++ b/test/scenes/scene-default/docker-compose.yaml
@@ -11,17 +11,17 @@ services:
     extends:
       file: ../common/base.yaml
       service: phpmyadmin
-  mongo:
-    extends:
-      file: ../common/base.yaml
-      service: mongo
-  mongo-express:
-    extends:
-      file: ../common/base.yaml
-      service: mongo-express
-    depends_on:
-      mongo:
-        condition: service_healthy
+#  mongo:
+#    extends:
+#      file: ../common/base.yaml
+#      service: mongo
+#  mongo-express:
+#    extends:
+#      file: ../common/base.yaml
+#      service: mongo-express
+#    depends_on:
+#      mongo:
+#        condition: service_healthy
   ceresdb:
     extends:
       file: ../common/base.yaml
@@ -70,8 +70,8 @@ services:
     depends_on:
       mysql-data-init:
         condition: service_completed_successfully
-      mongo:
-        condition: service_healthy
+#      mongo:
+#        condition: service_healthy
       ceresdb:
         condition: service_healthy
       es:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #452 

# Rationale for this change

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
 1. By default, metadata is stored using MySQL. 
 2. It supports using MySQL to store metadata by setting meta.db_data_mode = MySQL. 
 3. Added the ability to clean up historical metadata that has been taken offline.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
no
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
local test
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
