### PR TITLE
feat(home): log sample alert

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotify.java
@@ -92,6 +92,8 @@ public class AlertNotify {
   // log analysis content
   private List<String> logAnalysis;
 
+  private List<String> logSample;
+
   public static AlertNotify eventInfoConvert(EventInfo eventInfo, InspectConfig inspectConfig) {
     AlertNotify alertNotify = new AlertNotify();
     BeanUtils.copyProperties(inspectConfig, alertNotify);

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotifyRequest.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/model/event/AlertNotifyRequest.java
@@ -67,4 +67,6 @@ public class AlertNotifyRequest {
   // log analysis content
   private List<String> logAnalysis;
 
+  private List<String> logSample;
+
 }

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertNotifyHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertNotifyHandler.java
@@ -79,6 +79,7 @@ public abstract class AlertNotifyHandler implements AlertHandlerExecutor {
     alertNotifyRequest.setTenant(getTenant(alertNotify));
     alertNotifyRequest.setWorkspace(getWorkspace(alertNotify));
     alertNotifyRequest.setLogAnalysis(alertNotify.getLogAnalysis());
+    alertNotifyRequest.setLogSample(alertNotify.getLogSample());
 
     if (!CollectionUtils.isEmpty(alertNotify.getNotifyDataInfos())) {
       alertNotifyRequest.setNotifyDataInfos(alertNotify.getNotifyDataInfos());

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/converter/DoConvert.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/converter/DoConvert.java
@@ -16,9 +16,13 @@ import io.holoinsight.server.home.facade.InspectConfig;
 import io.holoinsight.server.home.facade.PqlRule;
 import io.holoinsight.server.home.facade.Rule;
 import io.holoinsight.server.home.facade.TimeFilter;
+import io.holoinsight.server.home.facade.trigger.DataSource;
+import io.holoinsight.server.home.facade.trigger.Trigger;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
+import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,6 +54,7 @@ public class DoConvert {
       } else {
         inspectConfig.setRule(G.get().fromJson(alarmRuleDO.getRule(), Rule.class));
         inspectConfig.setIsPql(false);
+        inspectConfig.setMetrics(getMetricsFromRule(inspectConfig.getRule()));
       }
       inspectConfig.setTimeFilter(G.get().fromJson(alarmRuleDO.getTimeFilter(), TimeFilter.class));
       inspectConfig.setStatus(alarmRuleDO.getStatus() != 0);
@@ -60,6 +65,24 @@ public class DoConvert {
       LOGGER.error("fail to convert alarmRule {}", G.get().toJson(alarmRuleDO), e);
     }
     return inspectConfig;
+  }
+
+  private static List<String> getMetricsFromRule(Rule rule) {
+    List<String> metrics = new ArrayList<>();
+    if (rule == null || CollectionUtils.isEmpty(rule.getTriggers())) {
+      return metrics;
+    }
+    for (Trigger trigger : rule.getTriggers()) {
+      if (CollectionUtils.isEmpty(trigger.getDatasources())) {
+        continue;
+      }
+      for (DataSource dataSource : trigger.getDatasources()) {
+        if (StringUtils.isNotEmpty(dataSource.getMetric())) {
+          metrics.add(dataSource.getMetric());
+        }
+      }
+    }
+    return metrics;
   }
 
   public static WebhookInfo alertWebhookDoConverter(AlarmWebhook alertWebhook) {

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/event/alertManagerEvent/AlertManagerBuildMsgHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/event/alertManagerEvent/AlertManagerBuildMsgHandler.java
@@ -77,6 +77,7 @@ public class AlertManagerBuildMsgHandler implements AlertHandlerExecutor {
     try {
       // 实体转换为map
       Map<String, String> map = ObjectToMapUtil.generateObjectToStringMap(values);
+      map.put("alarmLevel", values.getAlarmLevel() == null ? "" : values.getAlarmLevel().getDesc());
       content = buildMsgWithMap(template, map);
     } catch (Exception e) {
 

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/InspectConfig.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/InspectConfig.java
@@ -5,6 +5,8 @@ package io.holoinsight.server.home.facade;
 
 import lombok.Data;
 
+import java.util.List;
+
 
 /**
  * @author wangsiyuan
@@ -56,4 +58,8 @@ public class InspectConfig {
   private Long sourceId;
 
   private boolean logPatternEnable;
+
+  private boolean logSampleEnable;
+
+  private List<String> metrics;
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/TemplateValue.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/TemplateValue.java
@@ -126,7 +126,7 @@ public class TemplateValue {
     this.metric = pql;
   }
 
-  public void setLogContent(List<String> logAnalysis) {
+  public void setLogContentFromLogAnalysis(List<String> logAnalysis) {
     if (CollectionUtils.isEmpty(logAnalysis)) {
       this.logContent = StringUtils.EMPTY;
     } else {
@@ -137,6 +137,32 @@ public class TemplateValue {
           (Map<String, Object>) map.getOrDefault("ipCountMap", new HashMap<>());
       sample = sample + " FROM [" + String.join(",", ipCountMap.keySet()) + "]";
       this.logContent = sample;
+    }
+  }
+
+  public void setLogContentFromLogSample(List<String> logSample) {
+    try {
+      if (!CollectionUtils.isEmpty(logSample)) {
+        String json = logSample.get(0);
+        Map<String, Object> map = J.toMap(json);
+        List<Map<String, Object>> samples = (List<Map<String, Object>>) map.get("samples");
+        if (CollectionUtils.isEmpty(samples)) {
+          return;
+        }
+        Map<String, Object> sample = samples.get(0);
+        String hostname = (String) sample.get("hostname");
+        List<List<String>> logs = (List<List<String>>) sample.get("logs");
+        if (CollectionUtils.isEmpty(logs) || CollectionUtils.isEmpty(logs.get(0))) {
+          return;
+        }
+        String sampleLog = logs.get(0).get(0);
+        sampleLog = sampleLog + " FROM [" + hostname + "]";
+        this.logContent = sampleLog;
+      }
+    } finally {
+      if (StringUtils.isEmpty(this.logContent)) {
+        this.logContent = StringUtils.EMPTY;
+      }
     }
   }
 }

--- a/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/AlertHistoryDetailExtra.java
+++ b/server/home/home-facade/src/main/java/io/holoinsight/server/home/facade/trigger/AlertHistoryDetailExtra.java
@@ -11,4 +11,6 @@ import java.util.List;
  */
 public class AlertHistoryDetailExtra {
   public List<String> logAnalysisContent;
+
+  public List<String> logSampleContent;
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #532 

# Rationale for this change
 
Check whether the metric is configured with log sampling during the alarm notification process. If log sampling is configured, attempt to query the log sampling result and include it in the notification result.

# What changes are included in this PR?

- Check whether the metric is configured with log sampling `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/task/CacheAlertTask.java`
-  Try to query the log sampling result `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/AlertSaveHistoryHandler.java`
- Add black list to avoid the alert task assigned in specified servers `server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/task/coordinator/CoordinatorService.java`

# Are there any user-facing changes?

None.

# How does this change test


