### PR TITLE
fix(home): avoid empty collection in sql `IN`

### DIFF
--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/UserinfoServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/UserinfoServiceImpl.java
@@ -62,6 +62,9 @@ public class UserinfoServiceImpl implements UserinfoService {
     if (ms == null || StringUtils.isEmpty(ms.tenant)) {
       return Collections.emptyMap();
     }
+    if (CollectionUtils.isEmpty(uidList)) {
+      return Collections.emptyMap();
+    }
     QueryWrapper<Userinfo> queryWrapper = new QueryWrapper<>();
     queryWrapper.eq("tenant", ms.getTenant());
     queryWrapper.in("uid", uidList);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Avoid empty collection in sql `IN`, so we should check uid list first.

# What changes are included in this PR?



# Are there any user-facing changes?

None.

# How does this change test


