### PR TITLE
feat(home): alert subscribe across tenants 

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/GetSubscriptionHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/GetSubscriptionHandler.java
@@ -151,8 +151,8 @@ public class GetSubscriptionHandler implements AlertHandlerExecutor {
           QueryWrapper<AlarmSubscribe> alertSubscribeQueryWrapper = new QueryWrapper<>();
           alertSubscribeQueryWrapper.eq("unique_id", alertNotify.getUniqueId());
           alertSubscribeQueryWrapper.eq("status", (byte) 1);
-          requestContextAdapter.queryWrapperTenantAdapt(alertSubscribeQueryWrapper,
-              alertNotify.getTenant(), alertNotify.getWorkspace());
+          requestContextAdapter.queryWrapperTenantAdapt(alertSubscribeQueryWrapper, null,
+              alertNotify.getWorkspace());
           addGlobalWebhook(alertNotify, alertWebhookMap);
           List<AlarmSubscribe> alertSubscribeList =
               alarmSubscribeDOMapper.selectList(alertSubscribeQueryWrapper);

--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/BaseFunction.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/service/calculate/BaseFunction.java
@@ -48,7 +48,11 @@ public abstract class BaseFunction implements FunctionLogic {
 
     long delta = getDelta(functionConfigParam.getPeriodType());
     Map<Long, Double> points = dataResult.getPoints();
-    result.setCurrentValue(points.get(functionConfigParam.getPeriod()));
+    Double currentValue = points.get(functionConfigParam.getPeriod());
+    if (currentValue == null && functionConfigParam.isZeroFill()) {
+      currentValue = 0d;
+    }
+    result.setCurrentValue(currentValue);
     long duration = functionConfigParam.getDuration();
     for (long i = 0; i < duration; i++) {
       long time = functionConfigParam.getPeriod() - i * 60000L;

--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapter.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapter.java
@@ -18,6 +18,7 @@ public interface RequestContextAdapter {
 
   QueryProto.PqlRangeRequest requestAdapte(QueryProto.PqlRangeRequest request);
 
-  <T> void queryWrapperTenantAdapte(QueryWrapper<T> queryWrapper, String tenant, String workspace);
+  <T> void queryWrapperTenantAdapt(QueryWrapper<T> queryWrapper, String tenant, String workspace);
 
+  String getWorkspace(boolean cross);
 }

--- a/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapterImpl.java
+++ b/server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapterImpl.java
@@ -4,6 +4,9 @@
 package io.holoinsight.server.home.common.service;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import io.holoinsight.server.home.common.util.scope.MonitorCookieUtil;
+import io.holoinsight.server.home.common.util.scope.MonitorScope;
+import io.holoinsight.server.home.common.util.scope.RequestContext;
 import io.holoinsight.server.query.grpc.QueryProto;
 import org.apache.commons.lang3.StringUtils;
 
@@ -25,7 +28,7 @@ public class RequestContextAdapterImpl implements RequestContextAdapter {
   }
 
   @Override
-  public <T> void queryWrapperTenantAdapte(QueryWrapper<T> queryWrapper, String tenant,
+  public <T> void queryWrapperTenantAdapt(QueryWrapper<T> queryWrapper, String tenant,
       String workspace) {
     if (queryWrapper != null) {
       if (StringUtils.isNotBlank(tenant)) {
@@ -35,5 +38,11 @@ public class RequestContextAdapterImpl implements RequestContextAdapter {
         queryWrapper.eq("workspace", workspace);
       }
     }
+  }
+
+  @Override
+  public String getWorkspace(boolean cross) {
+    MonitorScope ms = RequestContext.getContext().ms;
+    return ms.getWorkspace();
   }
 }

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/AlertSubscribeService.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/AlertSubscribeService.java
@@ -3,6 +3,7 @@
  */
 package io.holoinsight.server.home.biz.service;
 
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.IService;
 import io.holoinsight.server.home.dal.model.AlarmSubscribe;
 import io.holoinsight.server.home.dal.model.dto.AlarmSubscribeDTO;
@@ -21,9 +22,9 @@ public interface AlertSubscribeService extends IService<AlarmSubscribe> {
   Boolean saveDataBatch(AlarmSubscribeDTO alarmSubscribeDTO, String creator, String tenant,
       String workspace);
 
-  AlarmSubscribeDTO queryByUniqueId(Map<String, Object> columnMap);
+  AlarmSubscribeDTO queryByUniqueId(QueryWrapper<AlarmSubscribe> queryWrapper, String uniqueId);
 
-  List<AlarmSubscribeInfo> queryByMap(Map<String, Object> columnMap);
+  List<AlarmSubscribeInfo> queryByMap(QueryWrapper<AlarmSubscribe> queryWrapper);
 
   Long save(AlarmSubscribeInfo alarmSubscribeInfo);
 

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlarmHistoryDetailServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlarmHistoryDetailServiceImpl.java
@@ -57,7 +57,7 @@ public class AlarmHistoryDetailServiceImpl extends
       wrapper.eq("alarm_time", alarmHistoryDetail.getAlarmTime());
     }
 
-    this.requestContextAdapter.queryWrapperTenantAdapte(wrapper,
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper,
         alarmHistoryDetail.getTenant().trim(), alarmHistoryDetail.getWorkspace());
 
     if (null != pageRequest.getFrom()) {
@@ -105,7 +105,7 @@ public class AlarmHistoryDetailServiceImpl extends
     if (StringUtils.isNotBlank(target.getUniqueId())) {
       queryWrapper.eq("unique_id", target.getUniqueId());
     }
-    this.requestContextAdapter.queryWrapperTenantAdapte(queryWrapper, target.getTenant(),
+    this.requestContextAdapter.queryWrapperTenantAdapt(queryWrapper, target.getTenant(),
         target.getWorkspace());
 
     queryWrapper.between("gmt_create",

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlarmHistoryServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlarmHistoryServiceImpl.java
@@ -15,7 +15,6 @@ import io.holoinsight.server.home.facade.page.MonitorPageResult;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -38,7 +37,7 @@ public class AlarmHistoryServiceImpl extends ServiceImpl<AlarmHistoryMapper, Ala
   public AlarmHistoryDTO queryById(Long id, String tenant, String workspace) {
 
     QueryWrapper<AlarmHistory> wrapper = new QueryWrapper<>();
-    this.requestContextAdapter.queryWrapperTenantAdapte(wrapper, tenant, workspace);
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper, tenant, workspace);
 
     wrapper.eq("id", id);
     wrapper.last("LIMIT 1");
@@ -61,7 +60,7 @@ public class AlarmHistoryServiceImpl extends ServiceImpl<AlarmHistoryMapper, Ala
       wrapper.eq("id", alarmHistory.getId());
     }
 
-    this.requestContextAdapter.queryWrapperTenantAdapte(wrapper, alarmHistory.getTenant(),
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper, alarmHistory.getTenant(),
         alarmHistory.getWorkspace());
 
     if (null != alarmHistory.getUniqueId()) {

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertDingDingRobotServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertDingDingRobotServiceImpl.java
@@ -7,6 +7,7 @@ import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import io.holoinsight.server.home.biz.service.AlertDingDingRobotService;
+import io.holoinsight.server.home.common.service.RequestContextAdapter;
 import io.holoinsight.server.home.common.util.StringUtil;
 import io.holoinsight.server.home.dal.converter.AlarmDingDingRobotConverter;
 import io.holoinsight.server.home.dal.mapper.AlarmDingDingRobotMapper;
@@ -14,6 +15,7 @@ import io.holoinsight.server.home.dal.model.AlarmDingDingRobot;
 import io.holoinsight.server.home.dal.model.dto.AlarmDingDingRobotDTO;
 import io.holoinsight.server.home.facade.page.MonitorPageRequest;
 import io.holoinsight.server.home.facade.page.MonitorPageResult;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
@@ -30,6 +32,9 @@ public class AlertDingDingRobotServiceImpl extends
 
   @Resource
   private AlarmDingDingRobotConverter alarmDingDingRobotConverter;
+
+  @Autowired
+  private RequestContextAdapter requestContextAdapter;
 
   @Override
   public Long save(AlarmDingDingRobotDTO alarmDingDingRobotDTO) {
@@ -49,7 +54,8 @@ public class AlertDingDingRobotServiceImpl extends
   @Override
   public AlarmDingDingRobotDTO queryById(Long id, String tenant) {
     QueryWrapper<AlarmDingDingRobot> wrapper = new QueryWrapper<>();
-    wrapper.eq("tenant", tenant);
+    requestContextAdapter.queryWrapperTenantAdapt(wrapper, tenant,
+        requestContextAdapter.getWorkspace(true));
     wrapper.eq("id", id);
     wrapper.last("LIMIT 1");
     AlarmDingDingRobot alarmDingDingRobot = this.getOne(wrapper);
@@ -68,12 +74,11 @@ public class AlertDingDingRobotServiceImpl extends
     AlarmDingDingRobot alarmDingDingRobot =
         alarmDingDingRobotConverter.dtoToDO(pageRequest.getTarget());
 
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper, alarmDingDingRobot.getTenant(),
+        alarmDingDingRobot.getWorkspace());
+
     if (null != alarmDingDingRobot.getId()) {
       wrapper.eq("id", alarmDingDingRobot.getId());
-    }
-
-    if (StringUtil.isNotBlank(alarmDingDingRobot.getTenant())) {
-      wrapper.eq("tenant", alarmDingDingRobot.getTenant().trim());
     }
 
     if (StringUtil.isNotBlank(alarmDingDingRobot.getGroupName())) {

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertGroupServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertGroupServiceImpl.java
@@ -7,6 +7,7 @@ import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import io.holoinsight.server.home.biz.service.AlertGroupService;
+import io.holoinsight.server.home.common.service.RequestContextAdapter;
 import io.holoinsight.server.home.dal.converter.AlarmGroupConverter;
 import io.holoinsight.server.home.dal.mapper.AlarmGroupMapper;
 import io.holoinsight.server.home.dal.model.AlarmGroup;
@@ -14,6 +15,7 @@ import io.holoinsight.server.home.dal.model.dto.AlarmGroupDTO;
 import io.holoinsight.server.home.facade.page.MonitorPageRequest;
 import io.holoinsight.server.home.facade.page.MonitorPageResult;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
@@ -25,6 +27,9 @@ public class AlertGroupServiceImpl extends ServiceImpl<AlarmGroupMapper, AlarmGr
 
   @Resource
   private AlarmGroupConverter alarmGroupConverter;
+
+  @Autowired
+  private RequestContextAdapter requestContextAdapter;
 
   @Override
   public Long save(AlarmGroupDTO alarmGroupDTO) {
@@ -42,7 +47,8 @@ public class AlertGroupServiceImpl extends ServiceImpl<AlarmGroupMapper, AlarmGr
   @Override
   public AlarmGroupDTO queryById(Long id, String tenant) {
     QueryWrapper<AlarmGroup> wrapper = new QueryWrapper<>();
-    wrapper.eq("tenant", tenant);
+    requestContextAdapter.queryWrapperTenantAdapt(wrapper, tenant,
+        requestContextAdapter.getWorkspace(true));
     wrapper.eq("id", id);
     wrapper.last("LIMIT 1");
     AlarmGroup alarmGroup = this.getOne(wrapper);
@@ -67,29 +73,28 @@ public class AlertGroupServiceImpl extends ServiceImpl<AlarmGroupMapper, AlarmGr
 
     QueryWrapper<AlarmGroup> wrapper = new QueryWrapper<>();
 
-    AlarmGroup alarmHistory = alarmGroupConverter.dtoToDO(pageRequest.getTarget());
+    AlarmGroup alarmGroup = alarmGroupConverter.dtoToDO(pageRequest.getTarget());
 
-    if (null != alarmHistory.getId()) {
-      wrapper.eq("id", alarmHistory.getId());
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper, alarmGroup.getTenant(),
+        alarmGroup.getWorkspace());
+
+    if (null != alarmGroup.getId()) {
+      wrapper.eq("id", alarmGroup.getId());
     }
 
-    if (StringUtils.isNotBlank(alarmHistory.getTenant())) {
-      wrapper.eq("tenant", alarmHistory.getTenant().trim());
+    if (null != alarmGroup.getEnvType()) {
+      wrapper.eq("env_type", alarmGroup.getEnvType());
     }
 
-    if (null != alarmHistory.getEnvType()) {
-      wrapper.eq("env_type", alarmHistory.getEnvType());
+    if (StringUtils.isNotBlank(alarmGroup.getGroupName())) {
+      wrapper.like("group_name", alarmGroup.getGroupName().trim());
     }
 
-    if (StringUtils.isNotBlank(alarmHistory.getGroupName())) {
-      wrapper.like("group_name", alarmHistory.getGroupName().trim());
+    if (StringUtils.isNotBlank(alarmGroup.getCreator())) {
+      wrapper.like("creator", alarmGroup.getCreator().trim());
     }
-
-    if (StringUtils.isNotBlank(alarmHistory.getCreator())) {
-      wrapper.like("creator", alarmHistory.getCreator().trim());
-    }
-    if (StringUtils.isNotBlank(alarmHistory.getModifier())) {
-      wrapper.like("modifier", alarmHistory.getModifier().trim());
+    if (StringUtils.isNotBlank(alarmGroup.getModifier())) {
+      wrapper.like("modifier", alarmGroup.getModifier().trim());
     }
 
     wrapper.orderByDesc("id");

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertRuleServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertRuleServiceImpl.java
@@ -74,7 +74,7 @@ public class AlertRuleServiceImpl extends ServiceImpl<AlarmRuleMapper, AlarmRule
   @Override
   public AlarmRuleDTO queryById(Long id, String tenant, String workspace) {
     QueryWrapper<AlarmRule> wrapper = new QueryWrapper<>();
-    this.requestContextAdapter.queryWrapperTenantAdapte(wrapper, tenant, workspace);
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper, tenant, workspace);
 
     wrapper.eq("id", id);
     wrapper.last("LIMIT 1");
@@ -100,7 +100,7 @@ public class AlertRuleServiceImpl extends ServiceImpl<AlarmRuleMapper, AlarmRule
       wrapper.eq("id", alarmRule.getId());
     }
 
-    this.requestContextAdapter.queryWrapperTenantAdapte(wrapper, alarmRule.getTenant(),
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper, alarmRule.getTenant(),
         alarmRule.getWorkspace());
 
     if (null != alarmRule.getStatus()) {
@@ -223,7 +223,7 @@ public class AlertRuleServiceImpl extends ServiceImpl<AlarmRuleMapper, AlarmRule
   @Override
   public List<AlarmRuleDTO> getListByKeyword(String keyword, String tenant, String workspace) {
     QueryWrapper<AlarmRule> wrapper = new QueryWrapper<>();
-    this.requestContextAdapter.queryWrapperTenantAdapte(wrapper, tenant, workspace);
+    this.requestContextAdapter.queryWrapperTenantAdapt(wrapper, tenant, workspace);
 
     wrapper.like("id", keyword).or().like("rule_name", keyword);
     wrapper.last("LIMIT 10");

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertSubscribeServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/service/impl/AlertSubscribeServiceImpl.java
@@ -3,6 +3,7 @@
  */
 package io.holoinsight.server.home.biz.service.impl;
 
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import io.holoinsight.server.home.biz.service.AlertSubscribeService;
 import io.holoinsight.server.home.dal.converter.AlarmSubscribeConverter;
@@ -33,6 +34,9 @@ public class AlertSubscribeServiceImpl extends ServiceImpl<AlarmSubscribeMapper,
 
   @Resource
   private AlarmSubscribeConverter alarmSubscribeConverter;
+
+  @Resource
+  private AlarmSubscribeMapper alarmSubscribeMapper;
 
   public Boolean saveDataBatch(AlarmSubscribeDTO alarmSubscribeDTO, String creator, String tenant,
       String workspace) {
@@ -80,10 +84,11 @@ public class AlertSubscribeServiceImpl extends ServiceImpl<AlarmSubscribeMapper,
   }
 
   @Override
-  public AlarmSubscribeDTO queryByUniqueId(Map<String, Object> columnMap) {
+  public AlarmSubscribeDTO queryByUniqueId(QueryWrapper<AlarmSubscribe> queryWrapper,
+      String uniqueId) {
     AlarmSubscribeDTO alarmSubscribeDTO = new AlarmSubscribeDTO();
-    alarmSubscribeDTO.setUniqueId((String) columnMap.get("unique_id"));
-    List<AlarmSubscribe> list = this.listByMap(columnMap);
+    alarmSubscribeDTO.setUniqueId(uniqueId);
+    List<AlarmSubscribe> list = this.alarmSubscribeMapper.selectList(queryWrapper);
     if (!CollectionUtils.isEmpty(list)) {
       alarmSubscribeDTO.setEnvType(list.get(0).getEnvType());
     }
@@ -92,8 +97,9 @@ public class AlertSubscribeServiceImpl extends ServiceImpl<AlarmSubscribeMapper,
   }
 
   @Override
-  public List<AlarmSubscribeInfo> queryByMap(Map<String, Object> columnMap) {
-    return alarmSubscribeConverter.dosToDTOs(this.listByMap(columnMap));
+  public List<AlarmSubscribeInfo> queryByMap(QueryWrapper<AlarmSubscribe> queryWrapper) {
+    List<AlarmSubscribe> list = this.alarmSubscribeMapper.selectList(queryWrapper);
+    return alarmSubscribeConverter.dosToDTOs(list);
   }
 
   @Override

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmDingDingRobotFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmDingDingRobotFacadeImpl.java
@@ -5,6 +5,7 @@ package io.holoinsight.server.home.web.controller;
 
 import io.holoinsight.server.home.biz.service.AlertDingDingRobotService;
 import io.holoinsight.server.home.biz.service.UserOpLogService;
+import io.holoinsight.server.home.common.service.RequestContextAdapter;
 import io.holoinsight.server.home.common.util.MonitorException;
 import io.holoinsight.server.home.common.util.scope.AuthTargetType;
 import io.holoinsight.server.home.common.util.scope.MonitorScope;
@@ -49,6 +50,9 @@ public class AlarmDingDingRobotFacadeImpl extends BaseFacade {
   @Autowired
   private UserOpLogService userOpLogService;
 
+  @Autowired
+  private RequestContextAdapter requestContextAdapter;
+
   @PostMapping("/create")
   @ResponseBody
   @MonitorScopeAuth(targetType = AuthTargetType.TENANT, needPower = PowerConstants.EDIT)
@@ -72,6 +76,7 @@ public class AlarmDingDingRobotFacadeImpl extends BaseFacade {
         if (null != ms && !StringUtils.isEmpty(ms.tenant)) {
           alarmDingDingRobotDTO.setTenant(ms.tenant);
         }
+        alarmDingDingRobotDTO.setWorkspace(requestContextAdapter.getWorkspace(true));
         alarmDingDingRobotDTO.setGmtCreate(new Date());
         alarmDingDingRobotDTO.setGmtModified(new Date());
         Long id = alarmDingDingRobotService.save(alarmDingDingRobotDTO);
@@ -121,9 +126,7 @@ public class AlarmDingDingRobotFacadeImpl extends BaseFacade {
           alarmDingDingRobotDTO.setModifier(mu.getLoginName());
         }
         MonitorScope ms = RequestContext.getContext().ms;
-        if (null != ms && !StringUtils.isEmpty(ms.tenant)) {
-          alarmDingDingRobotDTO.setTenant(ms.tenant);
-        }
+
         alarmDingDingRobotDTO.setGmtModified(new Date());
         boolean save = alarmDingDingRobotService.updateById(alarmDingDingRobotDTO);
 
@@ -177,7 +180,8 @@ public class AlarmDingDingRobotFacadeImpl extends BaseFacade {
         boolean rtn = false;
         AlarmDingDingRobotDTO alarmDingDingRobot =
             alarmDingDingRobotService.queryById(id, ms.getTenant());
-        if (alarmDingDingRobot != null) {
+        if (alarmDingDingRobot != null
+            && StringUtils.equals(alarmDingDingRobot.getTenant(), ms.getTenant())) {
           rtn = alarmDingDingRobotService.removeById(id);
         }
 
@@ -209,6 +213,7 @@ public class AlarmDingDingRobotFacadeImpl extends BaseFacade {
         if (null != ms && !StringUtils.isEmpty(ms.tenant)) {
           pageRequest.getTarget().setTenant(ms.tenant);
         }
+        pageRequest.getTarget().setWorkspace(requestContextAdapter.getWorkspace(true));
         JsonResult.createSuccessResult(result,
             alarmDingDingRobotService.getListByPage(pageRequest));
       }

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmSubscribeFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/AlarmSubscribeFacadeImpl.java
@@ -4,11 +4,12 @@
 package io.holoinsight.server.home.web.controller;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import io.holoinsight.server.home.common.service.RequestContextAdapter;
+import io.holoinsight.server.home.dal.model.AlarmSubscribe;
 import io.holoinsight.server.home.dal.model.dto.AlarmSubscribeInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +50,9 @@ public class AlarmSubscribeFacadeImpl extends BaseFacade {
   @Autowired
   private ULAFacade ulaFacade;
 
+  @Autowired
+  private RequestContextAdapter requestContextAdapter;
+
   @GetMapping(value = "/queryByUniqueId/{uniqueId}")
   @MonitorScopeAuth(targetType = AuthTargetType.TENANT, needPower = PowerConstants.VIEW)
   public JsonResult<AlarmSubscribeDTO> queryByUniqueId(@PathVariable("uniqueId") String uniqueId) {
@@ -62,13 +66,12 @@ public class AlarmSubscribeFacadeImpl extends BaseFacade {
       @Override
       public void doManage() {
         MonitorScope ms = RequestContext.getContext().ms;
-        Map<String, Object> conditions = new HashMap<>();
-        conditions.put("unique_id", uniqueId);
-        conditions.put("tenant", MonitorCookieUtil.getTenantOrException());
-        if (StringUtils.isNotBlank(ms.getWorkspace())) {
-          conditions.put("workspace", ms.getWorkspace());
-        }
-        JsonResult.createSuccessResult(result, alarmSubscribeService.queryByUniqueId(conditions));
+        QueryWrapper<AlarmSubscribe> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("unique_id", uniqueId);
+        requestContextAdapter.queryWrapperTenantAdapt(queryWrapper, ms.getTenant(),
+            ms.getWorkspace());
+        JsonResult.createSuccessResult(result,
+            alarmSubscribeService.queryByUniqueId(queryWrapper, uniqueId));
       }
     });
     return result;
@@ -130,13 +133,12 @@ public class AlarmSubscribeFacadeImpl extends BaseFacade {
       @Override
       public void doManage() {
         MonitorScope ms = RequestContext.getContext().ms;
-        Map<String, Object> conditions = new HashMap<>();
-        conditions.put("unique_id", uniqueId);
-        conditions.put("tenant", MonitorCookieUtil.getTenantOrException());
-        if (StringUtils.isNotBlank(ms.getWorkspace())) {
-          conditions.put("workspace", ms.getWorkspace());
-        }
-        AlarmSubscribeDTO alarmSubscribeDTO = alarmSubscribeService.queryByUniqueId(conditions);
+        QueryWrapper<AlarmSubscribe> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("unique_id", uniqueId);
+        requestContextAdapter.queryWrapperTenantAdapt(queryWrapper, ms.getTenant(),
+            ms.getWorkspace());
+        AlarmSubscribeDTO alarmSubscribeDTO =
+            alarmSubscribeService.queryByUniqueId(queryWrapper, uniqueId);
 
         if (null == alarmSubscribeDTO
             || CollectionUtils.isEmpty(alarmSubscribeDTO.getAlarmSubscribe()))

--- a/server/home/home-web/src/test/java/io/holoinsight/server/home/web/controller/AlarmRuleFacadeImplTest.java
+++ b/server/home/home-web/src/test/java/io/holoinsight/server/home/web/controller/AlarmRuleFacadeImplTest.java
@@ -67,7 +67,7 @@ public class AlarmRuleFacadeImplTest {
 
     Mockito.when(facade.alarmGroupService.getListByUserLike("test_userId", "test_tenant"))
         .thenReturn(Collections.singletonList(alarmGroupDTO));
-    Mockito.when(facade.alarmSubscribeService.queryByMap(Mockito.anyMap()))
+    Mockito.when(facade.alarmSubscribeService.queryByMap(Mockito.any()))
         .thenReturn(Collections.singletonList(alarmSubscribeInfo));
     Mockito.when(facade.alarmRuleService.list(Mockito.any()))
         .thenReturn(Collections.singletonList(alarmRule));


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In some deployment scenarios, it is necessary to implement alarm subscription and notification across tenants. Therefore, the logic of setting tenant conditions needs to be abstracted into an interface, which may have different implementations in different scenarios.

# What changes are included in this PR?

- Interface for setting tenant conditions `server/home/home-common/src/main/java/io/holoinsight/server/home/common/service/RequestContextAdapter.java`

# Are there any user-facing changes?

None.

# How does this change test


