### PR TITLE
feat(home): add storage_tenant column in metric_info table

### DIFF
--- a/server/common/common-dao/src/main/java/io/holoinsight/server/common/dao/entity/MetricInfo.java
+++ b/server/common/common-dao/src/main/java/io/holoinsight/server/common/dao/entity/MetricInfo.java
@@ -50,6 +50,8 @@ public class MetricInfo {
 
   public boolean deleted;
 
+  public String storageTenant;
+
   @TableField(value = "`gmt_create`")
   public Date gmtCreate;
 

--- a/server/common/common-dao/src/main/java/io/holoinsight/server/common/dao/entity/dto/MetricInfoDTO.java
+++ b/server/common/common-dao/src/main/java/io/holoinsight/server/common/dao/entity/dto/MetricInfoDTO.java
@@ -45,6 +45,8 @@ public class MetricInfoDTO {
   public String ref;
   public String extInfo;
 
+  public String storageTenant;
+
   public Date gmtCreate;
 
   public Date gmtModified;

--- a/server/extension/extension-common-flyway/src/main/resources/db/migration/V14__230801_ADD_metricinfo_COLUMN.sql
+++ b/server/extension/extension-common-flyway/src/main/resources/db/migration/V14__230801_ADD_metricinfo_COLUMN.sql
@@ -6,4 +6,4 @@
 -- Table structure for metric_info
 -- ----------------------------
 ALTER TABLE `metric_info`
-    ADD COLUMN `storage_tenant` VARCHAR(200) NULL AFTER `ext_info`;
+    ADD COLUMN `storage_tenant` VARCHAR(200) NULL DEFAULT NULL COMMENT 'storage tenant' AFTER `ext_info`;

--- a/server/extension/extension-common-flyway/src/main/resources/db/migration/V14__230801_ADD_metricinfo_COLUMN.sql
+++ b/server/extension/extension-common-flyway/src/main/resources/db/migration/V14__230801_ADD_metricinfo_COLUMN.sql
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+-- ----------------------------
+-- Table structure for metric_info
+-- ----------------------------
+ALTER TABLE `metric_info`
+    ADD COLUMN `storage_tenant` VARCHAR(200) NULL AFTER `ext_info`;

--- a/server/home/home-task/src/main/java/io/holoinsight/server/home/task/AbstractMetricCrawlerBuilder.java
+++ b/server/home/home-task/src/main/java/io/holoinsight/server/home/task/AbstractMetricCrawlerBuilder.java
@@ -40,7 +40,8 @@ public abstract class AbstractMetricCrawlerBuilder implements MetricCrawlerBuild
       if (!CollectionUtils.isEmpty(model.getMetricInfoList())) {
         metricInfoList.addAll(model.getMetricInfoList());
       }
-      List<MetricInfo> list = getMetricInfoList(model.getMetric(), model.getTags());
+      List<MetricInfo> list =
+          getMetricInfoList(model.getMetric(), model.getTags(), model.getMetricInfoTemplate());
       if (!CollectionUtils.isEmpty(list)) {
         metricInfoList.addAll(list);
       }
@@ -50,7 +51,8 @@ public abstract class AbstractMetricCrawlerBuilder implements MetricCrawlerBuild
     return metricInfoList;
   }
 
-  protected abstract List<MetricInfo> getMetricInfoList(String metric, List<String> tags);
+  protected abstract List<MetricInfo> getMetricInfoList(String metric, List<String> tags,
+      MetricInfo metricInfoTemplate);
 
 
   public List<MetricInfoModel> getMetricInfoModel(String product) {
@@ -68,6 +70,7 @@ public abstract class AbstractMetricCrawlerBuilder implements MetricCrawlerBuild
     public String metric;
     public List<String> tags = new ArrayList<>();
     public List<MetricInfo> metricInfoList = new ArrayList<>();
+    public MetricInfo metricInfoTemplate;
   }
 
   public MetricInfo genMetricInfo(String tenant, String workspace, String organization,

--- a/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/ApmMetricCrawlerBuilder.java
+++ b/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/ApmMetricCrawlerBuilder.java
@@ -84,7 +84,8 @@ public class ApmMetricCrawlerBuilder extends AbstractMetricCrawlerBuilder {
   }
 
   @Override
-  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags) {
+  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags,
+      MetricInfo metricInfoTemplate) {
     return null;
   }
 }

--- a/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/JvmMetricCrawlerBuilder.java
+++ b/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/JvmMetricCrawlerBuilder.java
@@ -29,7 +29,8 @@ import static io.holoinsight.server.home.task.MetricCrawlerConstant.NUMBER_UNIT;
 public class JvmMetricCrawlerBuilder extends AbstractMetricCrawlerBuilder {
 
   @Override
-  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags) {
+  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags,
+      MetricInfo metricInfoTemplate) {
     List<MetricInfo> metricInfoList = new ArrayList<>();
 
     metricInfoList.add(genMetricInfo(GLOBAL_TENANT, GLOBAL_WORKSPACE, GLOBAL_ORGANIZATION, "jvm",

--- a/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/MysqlMetricCrawlerBuilder.java
+++ b/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/MysqlMetricCrawlerBuilder.java
@@ -33,7 +33,8 @@ import static io.holoinsight.server.home.task.MetricCrawlerConstant.NUMBER_UNIT;
 @MetricCrawler(code = "io.holoinsight.plugin.MysqlPlugin")
 public class MysqlMetricCrawlerBuilder extends AbstractMetricCrawlerBuilder {
   @Override
-  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags) {
+  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags,
+      MetricInfo metricInfoTemplate) {
 
     List<MetricInfo> metricInfoList = new ArrayList<>();
     Map<String, List<IntegrationMetricDTO>> listMap = J.fromJson(metricData,

--- a/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/PortCheckMetricCrawlerBuilder.java
+++ b/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/PortCheckMetricCrawlerBuilder.java
@@ -28,7 +28,8 @@ import static io.holoinsight.server.home.task.MetricCrawlerConstant.NUMBER_UNIT;
 public class PortCheckMetricCrawlerBuilder extends AbstractMetricCrawlerBuilder {
 
   @Override
-  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags) {
+  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags,
+      MetricInfo metricInfoTemplate) {
     List<MetricInfo> metricInfoList = new ArrayList<>();
 
     metricInfoList.add(genMetricInfo(GLOBAL_TENANT, GLOBAL_WORKSPACE, GLOBAL_ORGANIZATION,

--- a/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/SystemMetricCrawlerBuilder.java
+++ b/server/home/home-task/src/main/java/io/holoinsight/server/home/task/crawler/SystemMetricCrawlerBuilder.java
@@ -25,7 +25,8 @@ import static io.holoinsight.server.home.task.MetricCrawlerConstant.*;
 public class SystemMetricCrawlerBuilder extends AbstractMetricCrawlerBuilder {
 
   @Override
-  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags) {
+  protected List<MetricInfo> getMetricInfoList(String metric, List<String> tags,
+      MetricInfo metricInfoTemplate) {
     List<MetricInfo> metricInfoList = new ArrayList<>();
     metricInfoList.add(genMetricInfo(GLOBAL_TENANT, GLOBAL_WORKSPACE, GLOBAL_ORGANIZATION, "system",
         "CPU", "cpu_util", "k8s_pod_cpu_util", "cpu 使用率", PERCENT_UNIT, 60, tags));


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Add `storage_tenant` in `metric_info` table to accommodate different storage media.

# What changes are included in this PR?

- Add `storageTenant` in `server/common/common-dao/src/main/java/io/holoinsight/server/common/dao/entity/MetricInfo.java`
- Add `server/extension/extension-common-flyway/src/main/resources/db/migration/V14__230801_ADD_metricinfo_COLUMN.sql`

# Are there any user-facing changes?

None.

# How does this change test


