### PR TITLE
feat: storage event

### DIFF
--- a/server/apm/apm-boot/src/main/java/io/holoinsight/server/apm/bootstrap/HoloinsightApmConfiguration.java
+++ b/server/apm/apm-boot/src/main/java/io/holoinsight/server/apm/bootstrap/HoloinsightApmConfiguration.java
@@ -5,13 +5,14 @@ package io.holoinsight.server.apm.bootstrap;
 
 import io.holoinsight.server.apm.core.installer.ModelInstallManager;
 import io.holoinsight.server.apm.engine.elasticsearch.storage.impl.CommonBuilder;
-import io.holoinsight.server.apm.receiver.analysis.ServiceErrorAnalysis;
 import io.holoinsight.server.apm.receiver.analysis.RelationAnalysis;
+import io.holoinsight.server.apm.receiver.analysis.ServiceErrorAnalysis;
 import io.holoinsight.server.apm.receiver.analysis.SlowSqlAnalysis;
 import io.holoinsight.server.apm.receiver.common.PublicAttr;
 import io.holoinsight.server.apm.receiver.trace.SpanHandler;
 import io.holoinsight.server.apm.server.service.impl.EndpointRelationServiceImpl;
 import io.holoinsight.server.apm.server.service.impl.EndpointServiceImpl;
+import io.holoinsight.server.apm.server.service.impl.EventServiceImpl;
 import io.holoinsight.server.apm.server.service.impl.MetricServiceImpl;
 import io.holoinsight.server.apm.server.service.impl.NetworkAddressMappingServiceImpl;
 import io.holoinsight.server.apm.server.service.impl.ServiceErrorServiceImpl;
@@ -138,4 +139,8 @@ public class HoloinsightApmConfiguration {
     return new SlowSqlAnalysis();
   }
 
+  @Bean("eventService")
+  public EventServiceImpl eventService() {
+    return new EventServiceImpl();
+  }
 }

--- a/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/query/Event.java
+++ b/server/apm/apm-common/src/main/java/io/holoinsight/server/apm/common/model/query/Event.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.common.model.query;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class Event {
+  private String tenant;
+  private String id;
+  private String name;
+  private String type;
+  private long timestamp;
+  private Map<String, String> tags;
+}

--- a/server/apm/apm-server/apm-core/src/main/java/io/holoinsight/server/apm/core/installer/ModelInstallManager.java
+++ b/server/apm/apm-server/apm-core/src/main/java/io/holoinsight/server/apm/core/installer/ModelInstallManager.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -27,10 +28,10 @@ import java.util.List;
 @Slf4j
 public class ModelInstallManager implements IModelInstallManager {
 
-  private static final String MODEL_PATH = "io.holoinsight.server.apm";
+  protected static final String MODEL_PATH = "io.holoinsight.server.apm";
 
-  public String getModelPath() {
-    return MODEL_PATH;
+  public String[] getModelPath() {
+    return new String[] {MODEL_PATH};
   }
 
 
@@ -51,9 +52,12 @@ public class ModelInstallManager implements IModelInstallManager {
     }
   }
 
-  private List<Model> scanModels() throws IOException {
+  protected List<Model> scanModels() throws IOException {
     List<Model> models = new ArrayList<>();
-    Collection<Class<?>> modelPathClasses = ClassUtil.getClasses(getModelPath());
+    Collection<Class<?>> modelPathClasses = new HashSet<>();
+    for (String modelPath : getModelPath()) {
+      modelPathClasses.addAll(ClassUtil.getClasses(modelPath));
+    }
     log.info("[apm] load {} models, path={}", modelPathClasses.size(), getModelPath());
     for (Class<?> cls : modelPathClasses) {
       if (cls.isAnnotationPresent(ModelAnnotation.class)) {
@@ -63,7 +67,7 @@ public class ModelInstallManager implements IModelInstallManager {
     return models;
   }
 
-  private Model scanModel(Class<?> cls) {
+  protected Model scanModel(Class<?> cls) {
     ModelAnnotation modelAnnotation = cls.getAnnotation(ModelAnnotation.class);
     List<Field> fields = new ArrayList<>();
     while (cls != null) {

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/HoloinsightEsConfiguration.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/HoloinsightEsConfiguration.java
@@ -6,6 +6,7 @@ package io.holoinsight.server.apm.engine.elasticsearch;
 import io.holoinsight.server.apm.engine.elasticsearch.installer.EsModelInstaller;
 import io.holoinsight.server.apm.engine.elasticsearch.storage.impl.EndpointEsStorage;
 import io.holoinsight.server.apm.engine.elasticsearch.storage.impl.EndpointRelationEsStorage;
+import io.holoinsight.server.apm.engine.elasticsearch.storage.impl.EventEsStorage;
 import io.holoinsight.server.apm.engine.elasticsearch.storage.impl.NetworkAddressMappingEsStorage;
 import io.holoinsight.server.apm.engine.elasticsearch.storage.impl.ServiceErrorEsStorage;
 import io.holoinsight.server.apm.engine.elasticsearch.storage.impl.ServiceInstanceEsStorage;
@@ -170,4 +171,9 @@ public class HoloinsightEsConfiguration {
     return new VirtualComponentEsStorage();
   }
 
+  @Bean("eventEsStorage")
+  @Primary
+  public EventEsStorage eventEsStorage() {
+    return new EventEsStorage();
+  }
 }

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/EventEsStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/storage/impl/EventEsStorage.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.engine.elasticsearch.storage.impl;
+
+import io.holoinsight.server.apm.common.model.query.Event;
+import io.holoinsight.server.apm.engine.elasticsearch.utils.ApmGsonUtils;
+import io.holoinsight.server.apm.engine.model.EventDO;
+import io.holoinsight.server.apm.engine.model.RecordDO;
+import io.holoinsight.server.apm.engine.storage.EventStorage;
+import io.holoinsight.server.apm.engine.storage.ICommonBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class EventEsStorage extends RecordEsStorage<EventDO> implements EventStorage {
+
+  @Autowired
+  private RestHighLevelClient client;
+
+  @Autowired
+  private ICommonBuilder commonBuilder;
+
+  protected RestHighLevelClient client() {
+    return client;
+  }
+
+  @Override
+  public List<Event> queryEvents(String tenant, long startTime, long endTime,
+      Map<String, String> termParams) throws Exception {
+    BoolQueryBuilder queryBuilder =
+        QueryBuilders.boolQuery().must(QueryBuilders.termQuery(EventDO.TENANT, tenant))
+            .must(QueryBuilders.rangeQuery(RecordDO.TIMESTAMP).gte(startTime).lte(endTime));
+
+    commonBuilder.addTermParams(queryBuilder, termParams);
+    SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+    sourceBuilder.size(1000);
+    sourceBuilder.query(queryBuilder);
+
+    SearchRequest searchRequest = new SearchRequest(EventDO.INDEX_NAME);
+    searchRequest.source(sourceBuilder);
+    SearchResponse response = client().search(searchRequest, RequestOptions.DEFAULT);
+
+    List<Event> result = new ArrayList<>();
+    for (SearchHit searchHit : response.getHits().getHits()) {
+      String hitJson = searchHit.getSourceAsString();
+      EventDO eventDO = ApmGsonUtils.apmGson().fromJson(hitJson, EventDO.class);
+      Event event = new Event();
+      BeanUtils.copyProperties(eventDO, event);
+      result.add(event);
+    }
+
+    return result;
+  }
+
+}

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/utils/ApmGsonUtils.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/elasticsearch/utils/ApmGsonUtils.java
@@ -41,6 +41,7 @@ public class ApmGsonUtils extends GsonUtils {
                   new RecordTypeAdapter(ServiceErrorDO.class))
               .registerTypeHierarchyAdapter(NetworkAddressMappingDO.class,
                   new RecordTypeAdapter(NetworkAddressMappingDO.class))
+              .registerTypeHierarchyAdapter(EventDO.class, new RecordTypeAdapter(EventDO.class))
               .create();
         }
       }

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/model/EventDO.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/model/EventDO.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.engine.model;
+
+import io.holoinsight.server.apm.common.model.storage.annotation.Column;
+import io.holoinsight.server.apm.common.model.storage.annotation.FlatColumn;
+import io.holoinsight.server.apm.common.model.storage.annotation.ModelAnnotation;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+import static io.holoinsight.server.apm.engine.model.EventDO.INDEX_NAME;
+
+
+/**
+ * @author sw1136562366
+ * @version : EventDO.java, v 0.1 2023年08月11日 20:34 sw1136562366 Exp $
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ModelAnnotation(name = INDEX_NAME)
+public class EventDO extends RecordDO {
+
+  public static final String INDEX_NAME = "holoinsight-event";
+
+  public static final String TENANT = "tenant";
+  public static final String ID = "id";
+  public static final String NAME = "name";
+  public static final String TYPE = "type";
+  public static final String TAGS = "tags";
+
+  @Column(name = TENANT)
+  private String tenant;
+  @Column(name = ID)
+  private String id;
+  @Column(name = NAME)
+  private String name;
+  @Column(name = TYPE)
+  private String type;
+  @FlatColumn
+  private Map<String, String> tags;
+
+  @Override
+  public String indexName() {
+    return INDEX_NAME;
+  }
+
+}

--- a/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/storage/EventStorage.java
+++ b/server/apm/apm-server/apm-engine/src/main/java/io/holoinsight/server/apm/engine/storage/EventStorage.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.engine.storage;
+
+import io.holoinsight.server.apm.common.model.query.Event;
+import io.holoinsight.server.apm.engine.model.EventDO;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author sw1136562366
+ * @version : EventStorage.java, v 0.1 2023年08月22日 16:56 sw1136562366 Exp $
+ */
+public interface EventStorage extends WritableStorage<EventDO> {
+  List<Event> queryEvents(String tenant, long startTime, long endTime,
+      Map<String, String> termParams) throws Exception;
+}

--- a/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/EventService.java
+++ b/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/EventService.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.server.service;
+
+import io.holoinsight.server.apm.common.model.query.Event;
+
+import java.util.List;
+import java.util.Map;
+
+public interface EventService {
+
+  List<Event> queryEvents(String tenant, long startTime, long endTime,
+      Map<String, String> termParams) throws Exception;
+
+  void insert(List<Event> events) throws Exception;
+}

--- a/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/EventServiceImpl.java
+++ b/server/apm/apm-server/apm-service/src/main/java/io/holoinsight/server/apm/server/service/impl/EventServiceImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.server.service.impl;
+
+import io.holoinsight.server.apm.common.model.query.Event;
+import io.holoinsight.server.apm.engine.model.EventDO;
+import io.holoinsight.server.apm.engine.storage.EventStorage;
+import io.holoinsight.server.apm.server.service.EventService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class EventServiceImpl implements EventService {
+
+  @Autowired
+  private EventStorage eventStorage;
+
+  @Override
+  public List<Event> queryEvents(String tenant, long startTime, long endTime,
+      Map<String, String> termParams) throws Exception {
+    return eventStorage.queryEvents(tenant, startTime, endTime, termParams);
+  }
+
+  @Override
+  public void insert(List<Event> events) throws Exception {
+    List<EventDO> eventDOS = new ArrayList<>();
+    for (Event event : events) {
+      EventDO eventDO = new EventDO();
+      BeanUtils.copyProperties(event, eventDO);
+      eventDOS.add(eventDO);
+    }
+    eventStorage.insert(eventDOS);
+  }
+}

--- a/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/ApmWebConfiguration.java
+++ b/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/ApmWebConfiguration.java
@@ -3,9 +3,8 @@
  */
 package io.holoinsight.server.apm.web;
 
-import io.holoinsight.server.apm.web.initializer.ApmInitializer;
-import io.holoinsight.server.common.springboot.ConditionalOnFeature;
 import io.holoinsight.server.apm.web.impl.EndpointApiController;
+import io.holoinsight.server.apm.web.impl.EventApiController;
 import io.holoinsight.server.apm.web.impl.MetricApiController;
 import io.holoinsight.server.apm.web.impl.ServiceApiController;
 import io.holoinsight.server.apm.web.impl.ServiceInstanceApiController;
@@ -13,7 +12,8 @@ import io.holoinsight.server.apm.web.impl.SlowSqlApiController;
 import io.holoinsight.server.apm.web.impl.TopologyApiController;
 import io.holoinsight.server.apm.web.impl.TraceApiController;
 import io.holoinsight.server.apm.web.impl.VirtualComponentApiController;
-
+import io.holoinsight.server.apm.web.initializer.ApmInitializer;
+import io.holoinsight.server.common.springboot.ConditionalOnFeature;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -71,4 +71,8 @@ public class ApmWebConfiguration {
     return new SlowSqlApiController();
   }
 
+  @Bean
+  public EventApiController eventApiController() {
+    return new EventApiController();
+  }
 }

--- a/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/EventApi.java
+++ b/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/EventApi.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.web;
+
+import io.holoinsight.server.apm.common.model.query.Event;
+import io.holoinsight.server.apm.common.model.query.Request;
+import io.holoinsight.server.apm.web.model.FailResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
+@Api(value = "event", description = "the event API")
+@RequestMapping("/cluster/api/v1/event")
+public interface EventApi {
+
+  @ApiOperation(value = "query event list", nickname = "queryEvents", notes = "",
+      response = Event.class, authorizations = {@Authorization(value = "APIKeyHeader"),
+          @Authorization(value = "APIKeyQueryParam")},
+      tags = {"events",})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "请求正常。", response = Event.class),
+      @ApiResponse(code = 400, message = "请求失败。", response = FailResponse.class)})
+  @RequestMapping(value = "/query", produces = {"application/json"},
+      consumes = {"application/json"}, method = RequestMethod.POST)
+  ResponseEntity<List<Event>> queryEvents(
+      @ApiParam(value = "查询条件。", required = true) @Valid @RequestBody Request request)
+      throws Exception;
+
+  @ApiOperation(value = "insert event list", nickname = "insertEvents", notes = "",
+      response = Event.class, authorizations = {@Authorization(value = "APIKeyHeader"),
+          @Authorization(value = "APIKeyQueryParam")},
+      tags = {"insertEvents",})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "请求正常。", response = Boolean.class),
+      @ApiResponse(code = 400, message = "请求失败。", response = FailResponse.class)})
+  @RequestMapping(value = "/insert", produces = {"application/json"},
+      consumes = {"application/json"}, method = RequestMethod.POST)
+  ResponseEntity<Boolean> insertEvents(
+      @ApiParam(value = "", required = true) @Valid @RequestBody List<Event> events)
+      throws Exception;
+}

--- a/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/impl/EventApiController.java
+++ b/server/apm/apm-server/apm-web/src/main/java/io/holoinsight/server/apm/web/impl/EventApiController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.apm.web.impl;
+
+import com.google.common.base.Strings;
+import io.holoinsight.server.apm.common.model.query.Event;
+import io.holoinsight.server.apm.common.model.query.Request;
+import io.holoinsight.server.apm.server.service.EventService;
+import io.holoinsight.server.apm.web.EventApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public class EventApiController implements EventApi {
+  @Autowired
+  private EventService eventService;
+
+  @Override
+  public ResponseEntity<List<Event>> queryEvents(Request request) throws Exception {
+    String tenant = request.getTenant();
+
+    if (Strings.isNullOrEmpty(tenant)) {
+      throw new IllegalArgumentException("The condition must contains tenant.");
+    }
+    List<Event> events = eventService.queryEvents(request.getTenant(), request.getStartTime(),
+        request.getEndTime(), request.getTermParams());
+    return ResponseEntity.ok(events);
+  }
+
+  @Override
+  public ResponseEntity<Boolean> insertEvents(List<Event> events) {
+    try {
+      eventService.insert(events);
+    } catch (Exception e) {
+      return ResponseEntity.ok(false);
+    }
+    return ResponseEntity.ok(true);
+  }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 This pr implements the es storage event and provides a query interface,
 the event is first added to the apm module.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Event data model，In order to make the design more general, only a few necessary fields are provided, and other additional fields should be added to `tags`
```
  private String tenant;
  private String id;
  private String name;
  private String type;
  private long timestamp;
  private Map<String, String> tags; 
```
Insert interface: io.holoinsight.server.apm.server.service.EventService.insert
Query interface: io.holoinsight.server.apm.server.service.EventService.queryEvents

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
