### PR TITLE
fix: sql injection

### DIFF
--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/MetricInfoCheckService.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/MetricInfoCheckService.java
@@ -3,6 +3,10 @@
  */
 package io.holoinsight.server.home.biz.plugin;
 
+import io.holoinsight.server.common.dao.entity.dto.MetricInfoDTO;
+
+import java.util.List;
+
 /**
  * @author masaimu
  * @version 2023-09-14 10:37:00
@@ -10,4 +14,6 @@ package io.holoinsight.server.home.biz.plugin;
 public interface MetricInfoCheckService {
 
   boolean needWorkspace(String product);
+
+  List<MetricInfoDTO> queryMetricInfoByMetricType(String product);
 }

--- a/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/MetricInfoCheckServiceImpl.java
+++ b/server/home/home-service/src/main/java/io/holoinsight/server/home/biz/plugin/MetricInfoCheckServiceImpl.java
@@ -3,6 +3,11 @@
  */
 package io.holoinsight.server.home.biz.plugin;
 
+import io.holoinsight.server.common.dao.entity.dto.MetricInfoDTO;
+
+import java.util.Collections;
+import java.util.List;
+
 /**
  * @author masaimu
  * @version 2023-09-14 10:45:00
@@ -11,5 +16,10 @@ public class MetricInfoCheckServiceImpl implements MetricInfoCheckService {
   @Override
   public boolean needWorkspace(String product) {
     return false;
+  }
+
+  @Override
+  public List<MetricInfoDTO> queryMetricInfoByMetricType(String product) {
+    return Collections.emptyList();
   }
 }

--- a/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/MetricInfoFacadeImpl.java
+++ b/server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/MetricInfoFacadeImpl.java
@@ -80,8 +80,18 @@ public class MetricInfoFacadeImpl extends BaseFacade {
         if (metricInfoCheckService.needWorkspace(product)) {
           workspace = ms.getWorkspace();
         }
-        JsonResult.createSuccessResult(result,
-            metricInfoService.queryListByTenantProduct(null, workspace, product.toLowerCase()));
+        List<MetricInfoDTO> list = new ArrayList<>();
+        List<MetricInfoDTO> r1 =
+            metricInfoService.queryListByTenantProduct(null, workspace, product.toLowerCase());
+        List<MetricInfoDTO> r2 =
+            metricInfoCheckService.queryMetricInfoByMetricType(product.toLowerCase());
+        if (!CollectionUtils.isEmpty(r1)) {
+          list.addAll(r1);
+        }
+        if (!CollectionUtils.isEmpty(r2)) {
+          list.addAll(r2);
+        }
+        JsonResult.createSuccessResult(result, list);
       }
     });
     return result;

--- a/server/home/home-web/src/test/java/io/holoinsight/server/home/web/controller/QueryFacadeImplTest.java
+++ b/server/home/home-web/src/test/java/io/holoinsight/server/home/web/controller/QueryFacadeImplTest.java
@@ -47,7 +47,6 @@ public class QueryFacadeImplTest {
         "select `period` , `app` , distinct(`aaa`) as dd from k8s_pod_mem_util where `period` <= 1691647903000 and `period` >= 1691644303000 and `app` in ('holoinsight-server','aaaaa') and `应用ID` = '111111111' group by `period` , `app` order by `period` asc",
         queryDataSource.ql));
 
-    queryFacade.parseAnalysisQl(queryDataSource, metricInfo);
     System.out.println(queryDataSource.ql);
     Assert.assertTrue(StringUtils.equals(
         "select `app` , distinct(`aaa`) as dd from k8s_pod_mem_util where `period` <= 1691647903000 and `period` >= 1691644303000 and `app` in ('holoinsight-server','aaaaa') and `应用ID` = '111111111' group by `app`",
@@ -59,7 +58,6 @@ public class QueryFacadeImplTest {
     metricInfo = new MetricInfo();
     metricInfo.setTags(J.toJson(Arrays.asList("app", "应用ID")));
     queryFacade = new QueryFacadeImpl();
-    queryFacade.parseAnalysisQl(queryDataSource, metricInfo);
     System.out.println(queryDataSource.ql);
     Assert.assertTrue(StringUtils.equals(
         "select `app` , distinct(`aaa`) as dd , `period` from k8s_pod_mem_util where `period` <= 1691647903000 and `period` >= 1691644303000 and `app` in ('holoinsight-server','aaaaa') and `应用ID` = '111111111' group by `app` order by `period` desc",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
To prevent SQL injection, restrict the query types to only allow querying `count(1)` or `approx_distinct`.

# What changes are included in this PR?

- Give restriction in `server/home/home-web/src/main/java/io/holoinsight/server/home/web/controller/QueryFacadeImpl.java`

# Are there any user-facing changes?

none.

# How does this change test


