### PR TITLE
feat: agg fill zero

### DIFF
--- a/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/AggTask.java
+++ b/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/AggTask.java
@@ -51,14 +51,21 @@ public class AggTask {
   private Window window;
   @Nonnull
   private Output output;
+
   /**
-   * agg task state config
+   * Agg task state config
    */
   private State state = new State();
+
+  /**
+   * Agg task fill-zero config
+   */
+  private FillZero fillZero = new FillZero();
 
   public AggTask() {}
 
   public boolean hasGroupBy() {
     return groupBy != null && !groupBy.isEmpty();
   }
+
 }

--- a/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/AggTaskVersion.java
+++ b/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/AggTaskVersion.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.agg.v1.core.conf;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Agg task version info
+ * <p>
+ * created at 2023/11/1
+ *
+ * @author xzchaoo
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AggTaskVersion {
+  private long id;
+  private long version;
+
+  public static AggTaskVersion of(AggTask t) {
+    return new AggTaskVersion(t.getId(), t.getVersion());
+  }
+
+  public boolean hasSameVersion(AggTask t) {
+    return id == t.getId() && version == t.getVersion();
+  }
+
+  public void updateTo(AggTask t) {
+    id = t.getId();
+    version = t.getVersion();
+  }
+
+  public boolean isEmpty() {
+    return id == 0 && version == 0;
+  }
+}

--- a/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/FillZero.java
+++ b/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/FillZero.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.agg.v1.core.conf;
+
+import java.util.concurrent.TimeUnit;
+
+import lombok.Data;
+
+/**
+ * Agg task fill-zero config
+ * <p>
+ * created at 2023/11/1
+ *
+ * @author xzchaoo
+ */
+@Data
+public class FillZero {
+  /**
+   * Whether to enable fill-zero logic
+   */
+  private boolean enabled = false;
+
+  /**
+   * Limit the maximum number of historyTags
+   */
+  private int keyLimit = 1000;
+
+  /**
+   * <p>
+   * This field represents the survival time of each history tag since its last occurrence.
+   * <p>
+   * Defaults to 1day.
+   */
+  private long expireTime = TimeUnit.DAYS.toMillis(1);
+}

--- a/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/executor/PartitionProcessor.java
+++ b/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/executor/PartitionProcessor.java
@@ -190,6 +190,7 @@ public class PartitionProcessor {
       XAggTask lastUsedAggTask = e.lastUsedAggTask;
       if (lastUsedAggTask == null) {
         lastUsedAggTask = aggTaskService.getAggTask(e.key().getAggId());
+        e.lastUsedAggTask = lastUsedAggTask;
       }
 
       if (lastUsedAggTask == null) {

--- a/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/state/AggTaskState.java
+++ b/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/state/AggTaskState.java
@@ -3,12 +3,15 @@
  */
 package io.holoinsight.server.agg.v1.executor.state;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 
+import io.holoinsight.server.agg.v1.core.conf.AggTaskVersion;
 import io.holoinsight.server.agg.v1.core.data.AggTaskKey;
+import io.holoinsight.server.agg.v1.executor.executor.FixedSizeTags;
 import io.holoinsight.server.agg.v1.executor.executor.XAggTask;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -45,7 +48,20 @@ public class AggTaskState {
   /**
    * Agg window state, keyed by time window start
    */
-  private Map<Long, AggWindowState> aggWindowStateMap = new TreeMap<>();
+  private TreeMap<Long, AggWindowState> aggWindowStateMap = new TreeMap<>();
+
+
+  /**
+   * This field represents the tags that have appeared in the aggregation task, and its value is the
+   * timestamp of the last occurrence of the corresponding tags.
+   */
+  private Map<FixedSizeTags, Long> historyTags = new HashMap<>();
+
+  /**
+   * This field indicates the version of AggTask corresponding to historyTags. Different versions of
+   * historyTags may be incompatible.
+   */
+  private AggTaskVersion historyTagsVersion = new AggTaskVersion();
 
   public AggTaskState(AggTaskKey key) {
     this.key = key;

--- a/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/state/AggWindowState.java
+++ b/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/state/AggWindowState.java
@@ -103,6 +103,29 @@ public class AggWindowState {
     return g;
   }
 
+  public boolean maybeCreateGroup(FixedSizeTags groupKey,
+      BiConsumer<AggWindowState, Group> callback) {
+
+    Group g = groupMap.get(groupKey);
+    if (g != null) {
+      return true;
+    }
+
+    // check key limit
+    if (groupMap.size() >= aggTask.getInner().getGroupBy().getKeyLimit()) {
+      return false;
+    }
+
+    g = new Group();
+    g.setTags(groupKey);
+    g.initGroupFields(aggTask.getSelect());
+    groupMap.put(groupKey, g);
+    if (callback != null) {
+      callback.accept(this, g);
+    }
+    return true;
+  }
+
   private FixedSizeTags buildGroupKey(DataAccessor da) {
     if (!aggTask.getInner().hasGroupBy()) {
       return FixedSizeTags.EMPTY;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When the agg task has no data at all in a certain period, it will not produce any output.
A certain combined dimension of the agg task appears in a certain time window, but may not appear again for a period of time.
Some product layer scenarios may expect the agg layer to have "fill-zero" capabilities. If there is no original data, a zero value will be filled in.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Agg supports 'fill-zero' when emitting.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
