### PR TITLE
feat: add kafka producer healthchecker

### DIFF
--- a/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/kafka/KafkaProducerHealthChecker.java
+++ b/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/kafka/KafkaProducerHealthChecker.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+package io.holoinsight.server.agg.v1.core.kafka;
+
+import java.time.Duration;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * <p>
+ * created at 2023/11/2
+ *
+ * @author xzchaoo
+ */
+@Slf4j
+public class KafkaProducerHealthChecker {
+  private static final int UNHEALTHY_CHECK_INTERVAL_MILLIS = 100;
+
+  private final KafkaProducer<?, ?> kp;
+  private final String testTopic;
+  private final Duration interval;
+  private final ScheduledExecutorService scheduler;
+  private final Executor ioExecutor;
+  @Getter
+  private volatile boolean healthy = true;
+  private volatile boolean stopped;
+
+  public KafkaProducerHealthChecker(KafkaProducer<?, ?> kp, String testTopic, Duration interval,
+      ScheduledExecutorService scheduler) {
+    this(kp, testTopic, interval, scheduler, scheduler);
+  }
+
+  public KafkaProducerHealthChecker(KafkaProducer<?, ?> kp, String testTopic, Duration interval,
+      ScheduledExecutorService scheduler, Executor ioExecutor) {
+    this.kp = kp;
+    this.testTopic = testTopic;
+    this.interval = interval;
+    this.scheduler = scheduler;
+    this.ioExecutor = ioExecutor;
+  }
+
+  public void start() {
+    scheduleNext();
+  }
+
+  private void scheduleNext() {
+    if (stopped) {
+      return;
+    }
+
+    try {
+      if (healthy) {
+        scheduler.schedule(this::checkOnce, interval.toMillis(), TimeUnit.MILLISECONDS);
+      } else {
+        scheduler.schedule(this::checkOnce, UNHEALTHY_CHECK_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+      }
+    } catch (RejectedExecutionException e) {
+      log.error("schedule rejected", e);
+    }
+  }
+
+  private void checkOnce() {
+    if (stopped) {
+      return;
+    }
+
+    if (scheduler == ioExecutor) {
+      checkOnce0();
+      scheduleNext();
+    } else {
+      ioExecutor.execute(() -> {
+        checkOnce0();
+        scheduleNext();
+      });
+    }
+  }
+
+  private void checkOnce0() {
+    long begin = System.currentTimeMillis();
+    try {
+      // When kafka is unhealthy, the partitionsFor method blocks for
+      // ProducerConfig.MAX_BLOCK_MS_CONFIG millis.
+      int partitions = kp.partitionsFor(testTopic).size();
+      long cost = System.currentTimeMillis() - begin;
+      healthy = true;
+      log.info("kafka producer healthcheck success testTopic=[{}] partitions=[{}] cost=[{}]", //
+          testTopic, partitions, cost);
+    } catch (Exception e) {
+      healthy = false;
+      long cost = System.currentTimeMillis() - begin;
+      log.error("kafka producer healthcheck error, testTopic=[{}] cost=[{}]", testTopic, cost, e);
+    }
+  }
+
+  public void stop() {
+    stopped = true;
+  }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When kafka is unhealthy, `kafkaProducer.send(record)` and `kafkaProducer.send(record, callback)` will block for ProducerConfig.MAX_BLOCK_MS_CONFIG millis.
This will cause the thread to block. I would prefer that we fail quickly when kafka fails.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add kafka producer healthchecker.  When kafka is detected to be unavailable, send is no longer called.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
