### PR TITLE
fix: restored from too old state

### DIFF
--- a/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/executor/PartitionProcessor.java
+++ b/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/executor/PartitionProcessor.java
@@ -281,7 +281,8 @@ public class PartitionProcessor {
 
     state.setRestoredOffset(restored.getOffset());
     for (AggTaskState ats : restored.getAggTaskStates().values()) {
-      log.info("[partition] [{}] load agg task restored {}", partition, ats.getKey());
+      log.info("[partition] [{}] load agg task restored {} watermark=[{}]", partition, ats.getKey(),
+          Utils.formatTime(ats.getWatermark()));
       AggTaskExecutor e = new AggTaskExecutor(ats, completenessService, output);
       e.restoredOffset = restored.getOffset();
       aggTaskExecutors.put(ats.getKey(), e);
@@ -292,8 +293,9 @@ public class PartitionProcessor {
     // automatically updated to reasonable values using the recalculation mechanism.
 
     long cost = System.currentTimeMillis() - begin;
-    log.info("[partition] [{}] load restored successfully, cost=[{}], aggTaskStates=[{}]",
-        partition, cost, restored.getAggTaskStates().size());
+    log.info("[partition] [{}] load restored successfully, cost=[{}], aggTaskStates=[{}] MET=[{}]",
+        partition, cost, restored.getAggTaskStates().size(),
+        Utils.formatTime(state.getMaxEventTimestamp()));
   }
 
   void clearState() {

--- a/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/state/PartitionState.java
+++ b/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/state/PartitionState.java
@@ -55,6 +55,7 @@ public class PartitionState {
     offset = 0L;
     aggTaskStates.clear();
     maxEventTimestamp = 0;
+    restoredOffset = 0;
   }
 
   public boolean updateMaxEventTimestamp(long timestamp) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When agg is restored from a very old state, the kafka message corresponding to the restored offset may have been deleted.
At this time, a lot of empty windows may be created in the `io.holoinsight.server.agg.v1.executor.executor.AggTaskExecutor#maybeFillZero` method, causing OOM.

# What changes are included in this PR?
Check the validity of the restored offset, and clear the status if it is not legal.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
