### PR TITLE
fix: get subscription for multiple alarm subscribers

### DIFF
--- a/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/GetSubscriptionHandler.java
+++ b/server/home/home-alert/src/main/java/io/holoinsight/server/home/alert/plugin/GetSubscriptionHandler.java
@@ -143,7 +143,9 @@ public class GetSubscriptionHandler implements AlertHandlerExecutor {
                       personList.add(userId);
                     }
                     if (!CollectionUtils.isEmpty(personList)) {
-                      userNotifyMap.put(noticeType, personList);
+                      List<String> list =
+                          userNotifyMap.computeIfAbsent(noticeType, k -> new ArrayList<>());
+                      list.addAll(personList);
                     }
                     break;
                   case "dingDingRobot":


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In the case that there are multiple alarm subscribe records, the older ones may be overrode by new one.

# What changes are included in this PR?

Fix it.

# Are there any user-facing changes?



# How does this change test


