### PR TITLE
feat: support discarding intermediate data when aggtask is updated

### DIFF
--- a/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/Extension.java
+++ b/server/agg/agg-core/src/main/java/io/holoinsight/server/agg/v1/core/conf/Extension.java
@@ -18,4 +18,10 @@ public class Extension {
    * Whether to enter debug mode
    */
   private boolean debug;
+
+  /**
+   * When an AggTask update is found, whether to discard the intermediate calculation results of the
+   * current cycle
+   */
+  private boolean discardWhenUpdate;
 }

--- a/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/executor/XAggTask.java
+++ b/server/agg/agg-executor/src/main/java/io/holoinsight/server/agg/v1/executor/executor/XAggTask.java
@@ -33,4 +33,8 @@ public class XAggTask {
     this.select = select;
     this.where = where;
   }
+
+  public boolean hasSameVersion(XAggTask aggTask) {
+    return inner.getVersion() == aggTask.getInner().getVersion();
+  }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change


# What changes are included in this PR?
When an AggTask update is found, discard the intermediate calculation results of
the current cycle. Doing so allows you to immediately update the day-level tasks instead of
waiting until the next day to take effect. But the disadvantage is that the intermediate
state will be lost and the data will be calculated from zero.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
