### PR TITLE
refactor: ConditionalOnRole

### DIFF
--- a/server/common/common/src/main/java/io/holoinsight/server/common/springboot/ConditionalOnRole.java
+++ b/server/common/common/src/main/java/io/holoinsight/server/common/springboot/ConditionalOnRole.java
@@ -30,4 +30,6 @@ public @interface ConditionalOnRole {
    * @return
    */
   String[] value();
+
+  boolean any() default true;
 }

--- a/server/common/common/src/main/java/io/holoinsight/server/common/springboot/ConditionalOnRoleCondition.java
+++ b/server/common/common/src/main/java/io/holoinsight/server/common/springboot/ConditionalOnRoleCondition.java
@@ -28,17 +28,25 @@ class ConditionalOnRoleCondition extends SpringBootCondition {
       AnnotatedTypeMetadata metadata) {
     Map<String, Object> attributes =
         metadata.getAnnotationAttributes(ConditionalOnRole.class.getName(), true);
-    String[] anyRole = (String[]) attributes.get("value");
-
+    String[] expectedRoles = (String[]) attributes.get("value");
+    boolean any = (Boolean) attributes.get("any");
     String roles = context.getEnvironment().getProperty("holoinsight.roles.active", "");
     Iterable<String> iter = Splitter.on(',').trimResults().omitEmptyStrings().split(roles);
 
-    for (String role : anyRole) {
-      if (Iterables.contains(iter, role)) {
-        return ConditionOutcome.match("match '" + role + "' role");
+    if (any) {
+      for (String role : expectedRoles) {
+        if (Iterables.contains(iter, role)) {
+          return ConditionOutcome.match("match '" + role + "' role");
+        }
+      }
+    } else {
+      for (String role : expectedRoles) {
+        if (!Iterables.contains(iter, role)) {
+          return ConditionOutcome.match("no match '" + role + "' role");
+        }
       }
     }
 
-    return ConditionOutcome.noMatch("no any roles: " + Arrays.toString(anyRole));
+    return ConditionOutcome.noMatch("no match roles: " + Arrays.toString(expectedRoles));
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
The original semantics of ConditionOnRole is that it takes effect when any role is activated.
Now there is a new parameter any, which is used to control the relationship between roles, whether it is 'any' or 'and'.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
